### PR TITLE
Disable Payments and Payment Requests While Syncing

### DIFF
--- a/packages/lightning-core/common/Input.js
+++ b/packages/lightning-core/common/Input.js
@@ -10,7 +10,7 @@ export class Input extends React.Component {
   handleBlur = () => this.setState({ focused: false })
   handleClick = () => {
     const { selectOnClick, copyOnClick, onCopy, onClick } = this.props
-    if (copyOnClick) {
+    if (copyOnClick && !this.props.disabled) {
       this.input.select()
 
       try {
@@ -26,7 +26,7 @@ export class Input extends React.Component {
   }
 
   render() {
-    const { name, right, left, type, placeholder, value, sanitizeReturn,
+    const { name, right, left, type, placeholder, value, sanitizeReturn, disabled,
       onChange, outlineColor, fullWidth } = this.props
     const styles = reactCSS({
       'default': {
@@ -74,8 +74,8 @@ export class Input extends React.Component {
           type={ type }
           placeholder={ placeholder }
           value={ value }
+          disabled={ disabled }
           onChange={ handleChange }
-
           onFocus={ this.handleFocus }
           onBlur={ this.handleBlur }
         />

--- a/packages/lightning-core/request/BitcoinWallet.js
+++ b/packages/lightning-core/request/BitcoinWallet.js
@@ -11,7 +11,7 @@ export class BitcoinWallet extends React.Component {
   componentDidMount() { this.props.onFetchAddress() }
 
   render() {
-    const { address, onSuccess, onShowQR } = this.props
+    const { address, isSynced, onSuccess, onShowQR } = this.props
 
     const styles = reactCSS({
       'default': {
@@ -47,8 +47,8 @@ export class BitcoinWallet extends React.Component {
       },
     })
 
-    const handleCopy = () => onSuccess('Copied to Clipboard')
-    const handleClick = () => onShowQR(QR_CODE)
+    const handleCopy = () => isSynced && onSuccess('Copied to Clipboard')
+    const handleClick = () => isSynced && onShowQR(QR_CODE)
 
     const label = (
       <div style={ styles.label }>Wallet Address</div>
@@ -70,6 +70,7 @@ export class BitcoinWallet extends React.Component {
           onCopy={ handleCopy }
           left={ label }
           value={ address }
+          disabled={ !isSynced }
         />
         <div style={ styles.icon }>
           <Icon name="qrcode" onClick={ handleClick } />

--- a/packages/lightning-core/request/index.js
+++ b/packages/lightning-core/request/index.js
@@ -10,7 +10,7 @@ import { CurrencyInput, Head, Input, Page } from '../common'
 import PaymentRequestPopup, { POPUP_NAME } from './PaymentRequestPopup'
 import BitcoinWallet from './BitcoinWallet'
 
-export const Pay = ({ showPopup, closePopup, paymentRequest, address,
+export const Pay = ({ showPopup, closePopup, paymentRequest, address, isSynced,
   onFetchAddress, onGeneratePaymentRequest, onSuccess }) => {
   const fields = [
     {
@@ -18,23 +18,28 @@ export const Pay = ({ showPopup, closePopup, paymentRequest, address,
       placeholder: 'Amount',
       required: true,
       component: CurrencyInput,
+      disabled: !isSynced,
     },
     {
       name: 'note',
       placeholder: 'Note',
       component: Input,
+      disabled: !isSynced,
     },
   ]
 
   const handleSuccess = ({ amount, note }, clear) => {
-    onGeneratePaymentRequest({ amount, note })
-      // eslint-disable-next-line no-console
-      .catch(console.error)
-    showPopup(POPUP_NAME)
-    clear()
+    if (isSynced) {
+      onGeneratePaymentRequest({ amount, note })
+        // eslint-disable-next-line no-console
+        .catch(console.error)
+      showPopup(POPUP_NAME)
+      clear()
+    }
   }
 
   const handleError = (errors) => {
+    // eslint-disable-next-line no-console
     console.log('error', errors)
   }
 
@@ -75,6 +80,7 @@ export const Pay = ({ showPopup, closePopup, paymentRequest, address,
       </Page>
       <BitcoinWallet
         address={ address }
+        isSynced={ isSynced }
         onSuccess={ onSuccess }
         onShowQR={ showPopup }
         onFetchAddress={ onFetchAddress }
@@ -87,6 +93,7 @@ export default connect(
   state => ({
     paymentRequest: store.getPaymentRequest(state),
     address: store.getAddress(state),
+    isSynced: store.getSyncedToChain(state),
   }), {
     showPopup: popupActions.onOpen,
     closePopup: popupActions.onClose,


### PR DESCRIPTION
Closes https://github.com/lightninglabs/lightning-app/issues/21 and https://github.com/lightninglabs/lightning-app/issues/24

* Inputs can be disabled
* QR Popup disabled while syncing
* Disable input copy to clipboard when disabled
* All GRPC calls guarded while syncing