### PR TITLE
Fix "blank app on start" bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ If you get any errors related to GRPC on startup, run:
 npm run setup
 ```
 
-If the window doesn't load after running `npm start`: try clicking on dev tools window and hitting `cmd-r` to refresh the window.
-
 ### Logs
 Logs are written to the following locations:
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,7 +11,7 @@
     "package": "cross-env NODE_ENV=production node -r babel-register -r babel-polyfill scripts/package.js",
     "package-all": "npm run package -- --all",
     "start": "node scripts/startup-message.js && concurrently --kill-others \"npm run start-electron\" \"npm run start-webpack\" -n \"electron,webpack\" -p name",
-    "start-electron": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./main.dev",
+    "start-electron": "sleep 3; cross-env HOT=1 NODE_ENV=development electron -r babel-register ./main.dev",
     "start-webpack": "cross-env NODE_ENV=development node -r babel-register scripts/dev-server.js",
     "install-grpc": "cd node_modules/grpc && git submodule update --init && npm run electron-build -- --target=1.4.6"
   },


### PR DESCRIPTION
### What issue(s) does this PR fix?
Fixes #68.

### What problem(s) are you solving?
Some background info:
- The start-webpack script starts our Node server. 
- The start-electron script starts the Electron app, which makes a HTTP request to our Node server.

----- 

When a developer runs `npm start`, many times the app will open up as a blank page. This is problematic for developers since some may not know the workaround is to press `Cmd + R`.

In terms of the code, there is a race condition between the start-electron and start-webpack scripts. When we run `npm start`, both of these scripts run concurrently. However, in order for this to work properly, start-webpack needs to give the start-electron script a few seconds before start-webpack can run, otherwise the app will open with a blank screen.

The culprit is line 143 in `apps/desktop/main.dev.js`. This line of code sends a HTTP request to localhost:4152, our Node server. If the Node server hasn’t started, the app will open up with a blank page.

### How did you solve this problem?
I added a sleep command to the start-electron script. This will ensure that the start-webpack script is provided a head start before the start-electron script begins.

### How did you test this?
- I ran `npm start` 10 times and each time the app loaded successfully.

### Is there anything special we should know?
None.

### Is there anything else we should know?
 - When testing this solution compared to the old code, the time it took for the app to load was negligible. With the new code I averaged 15 seconds for the app to load. With the old code I averaged 14 seconds.

- I'm not entirely pleased with this solution. However, after consideration I believe this is the best solution _for now_. The main issue here is that the start-electron script calls `localhost:4152`. If Node isn't running, then the app will open up with a blank screen. I could run a check to see if the Node server is running within the start-electron script, but that introduces more code that I feel is not entirely warranted (this issue only occurs for developers testing the app). 

  There does exist the possibility that the start-webpack script will evolve over time and end up taking longer to complete than the start-electron script making the sleep command irrelevant.

- It would not hurt my feelings if this solution was rejected. I imagine I could come up with a nifty solution given more time but there are bigger fish to fry at the moment (writing tests).
