### PR TITLE
Add progress bar for chain sync

### DIFF
--- a/apps/desktop/rpc.proto
+++ b/apps/desktop/rpc.proto
@@ -273,7 +273,7 @@ message GetInfoResponse {
 
     repeated string chains = 11 [ json_name = "chains" ];
 
-    uint32 synced_height = 12 [ json_name = "synced_height" ];
+    uint32 wallet_best_block_timestamp = 12 [ json_name = "wallet_best_block_timestamp" ];
 }
 
 message ConfirmationUpdate {

--- a/apps/desktop/rpc.proto
+++ b/apps/desktop/rpc.proto
@@ -272,6 +272,8 @@ message GetInfoResponse {
     bool testnet = 10 [ json_name = "testnet" ];
 
     repeated string chains = 11 [ json_name = "chains" ];
+
+    uint32 synced_height = 12 [ json_name = "synced_height" ];
 }
 
 message ConfirmationUpdate {

--- a/apps/desktop/rpc.proto
+++ b/apps/desktop/rpc.proto
@@ -273,7 +273,7 @@ message GetInfoResponse {
 
     repeated string chains = 11 [ json_name = "chains" ];
 
-    uint32 wallet_best_block_timestamp = 12 [ json_name = "wallet_best_block_timestamp" ];
+    uint32 best_header_timestamp = 12 [ json_name = "best_header_timestamp" ];
 }
 
 message ConfirmationUpdate {

--- a/packages/lightning-core/accounts/reducer.js
+++ b/packages/lightning-core/accounts/reducer.js
@@ -18,7 +18,9 @@ export const FETCH_ACCOUNT_FAILURE = 'ACCOUNTS/FETCH_ACCOUNT_ERROR'
 
 const initialState = {
   pubkey: '',
-  isSynced: true,
+  isSynced: false,
+  syncedHeight: 0,
+  blockHeight: 0,
   serverRunning: false,
   currency: 'satoshi',
   balances: {
@@ -37,9 +39,20 @@ export default (state = initialState, action) => {
     case REQUEST_CHANNELS:
       return { ...state, loadingChannels: true }
     case FETCH_ACCOUNT:
-      return { ...state, pubkey: action.pubkey, isSynced: action.isSynced }
+      return {
+        ...state,
+        pubkey: action.pubkey,
+        isSynced: action.isSynced,
+        syncedHeight: action.syncedHeight,
+        blockHeight: action.blockHeight
+    }
     case FETCH_ACCOUNT_FAILURE:
-      return { ...state, isSynced: false }
+      return {
+        ...state,
+        isSynced: false,
+        syncedHeight: 0,
+        blockHeight: 0
+    }
     case SET_BALANCES:
       return { ...state, balances: { ...state.balances, ...action.balances } }
     case PENDING_CHANNELS:
@@ -85,6 +98,8 @@ export const actions = {
       schema: account => ({
         pubkey: account.identity_pubkey,
         isSynced: account.synced_to_chain,
+        syncedHeight: account.synced_height,
+        blockHeight: account.block_height
       }),
     },
   }),
@@ -261,6 +276,8 @@ export const actions = {
 
 export const selectors = {
   getSyncedToChain: state => state.isSynced,
+  getSyncedHeight: state => state.syncedHeight,
+  getBlockHeight: state => state.blockHeight,
   getServerRunning: state => state.serverRunning,
   getAccountPubkey: state => state.pubkey,
   getCurrency: state => state.currency,

--- a/packages/lightning-core/accounts/reducer.js
+++ b/packages/lightning-core/accounts/reducer.js
@@ -19,7 +19,7 @@ export const FETCH_ACCOUNT_FAILURE = 'ACCOUNTS/FETCH_ACCOUNT_ERROR'
 const initialState = {
   pubkey: '',
   isSynced: false,
-  walWetBestBlockTimestamp: 0,
+  bestHeaderTimestamp: 0,
   blockHeight: 0,
   serverRunning: false,
   currency: 'satoshi',
@@ -43,14 +43,14 @@ export default (state = initialState, action) => {
         ...state,
         pubkey: action.pubkey,
         isSynced: action.isSynced,
-        walWetBestBlockTimestamp: action.walletBestBlockTimestamp,
+        bestHeaderTimestamp: action.bestHeaderTimestamp,
         blockHeight: action.blockHeight
     }
     case FETCH_ACCOUNT_FAILURE:
       return {
         ...state,
         isSynced: false,
-        walWetBestBlockTimestamp: 0,
+        bestHeaderTimestamp: 0,
         blockHeight: 0
     }
     case SET_BALANCES:
@@ -98,7 +98,7 @@ export const actions = {
       schema: account => ({
         pubkey: account.identity_pubkey,
         isSynced: account.synced_to_chain,
-        walWetBestBlockTimestamp: account.synced_height,
+        bestHeaderTimestamp: account.best_header_timestamp,
         blockHeight: account.block_height
       }),
     },
@@ -276,7 +276,7 @@ export const actions = {
 
 export const selectors = {
   getSyncedToChain: state => state.isSynced,
-  getWalletBestBlockTimestamp: state => state.walletBestBlockTimestamp,
+  getBestHeaderTimestamp: state => state.bestHeaderTimestamp,
   getBlockHeight: state => state.blockHeight,
   getServerRunning: state => state.serverRunning,
   getAccountPubkey: state => state.pubkey,

--- a/packages/lightning-core/accounts/reducer.js
+++ b/packages/lightning-core/accounts/reducer.js
@@ -19,7 +19,7 @@ export const FETCH_ACCOUNT_FAILURE = 'ACCOUNTS/FETCH_ACCOUNT_ERROR'
 const initialState = {
   pubkey: '',
   isSynced: false,
-  syncedHeight: 0,
+  walWetBestBlockTimestamp: 0,
   blockHeight: 0,
   serverRunning: false,
   currency: 'satoshi',
@@ -43,14 +43,14 @@ export default (state = initialState, action) => {
         ...state,
         pubkey: action.pubkey,
         isSynced: action.isSynced,
-        syncedHeight: action.syncedHeight,
+        walWetBestBlockTimestamp: action.walletBestBlockTimestamp,
         blockHeight: action.blockHeight
     }
     case FETCH_ACCOUNT_FAILURE:
       return {
         ...state,
         isSynced: false,
-        syncedHeight: 0,
+        walWetBestBlockTimestamp: 0,
         blockHeight: 0
     }
     case SET_BALANCES:
@@ -98,7 +98,7 @@ export const actions = {
       schema: account => ({
         pubkey: account.identity_pubkey,
         isSynced: account.synced_to_chain,
-        syncedHeight: account.synced_height,
+        walWetBestBlockTimestamp: account.synced_height,
         blockHeight: account.block_height
       }),
     },
@@ -276,7 +276,7 @@ export const actions = {
 
 export const selectors = {
   getSyncedToChain: state => state.isSynced,
-  getSyncedHeight: state => state.syncedHeight,
+  getWalletBestBlockTimestamp: state => state.walletBestBlockTimestamp,
   getBlockHeight: state => state.blockHeight,
   getServerRunning: state => state.serverRunning,
   getAccountPubkey: state => state.pubkey,

--- a/packages/lightning-core/common/Sidebar.js
+++ b/packages/lightning-core/common/Sidebar.js
@@ -16,7 +16,7 @@ export class Sidebar extends React.Component {
     this.state = {
       syncProgress: 0,
       fetchAccount: undefined,
-      initialWalletBestBlockTimestamp: 0
+      initialBestHeaderTimestamp: 0
     }
   }
 
@@ -29,23 +29,23 @@ export class Sidebar extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { isSynced, walletBestBlockTimestamp, blockHeight } = this.props
-    const { fetchAccountInterval, initialWalletBestBlockTimestamp } = this.state
-    if (initialWalletBestBlockTimestamp === 0 && walletBestBlockTimestamp)
-      this.setState({ initialWalletBestBlockTimestamp: walletBestBlockTimestamp }, () => {
-        setSyncProgress(this.state.initialWalletBestBlockTimestamp, walletBestBlockTimestamp)
+    const { isSynced, bestHeaderTimestamp, blockHeight } = this.props
+    const { fetchAccountInterval, initialBestHeaderTimestamp } = this.state
+    if (initialBestHeaderTimestamp === 0 && bestHeaderTimestamp)
+      this.setState({ initialBestHeaderTimestamp: bestHeaderTimestamp }, () => {
+        setSyncProgress(this.state.initialBestHeaderTimestamp, bestHeaderTimestamp)
       })
     !isSynced &&
       nextProps.isSynced &&
       clearInterval(fetchAccountInterval) &&
       this.setState({ fetchAccountInterval: undefined })
-    this.setSyncProgress(initialWalletBestBlockTimestamp, walletBestBlockTimestamp)
+    this.setSyncProgress(initialBestHeaderTimestamp, bestHeaderTimestamp)
   }
 
-  setSyncProgress(initialWalletBestBlockTimestamp, walletBestBlockTimestamp) {
+  setSyncProgress(initialBestHeaderTimestamp, bestHeaderTimestamp) {
     this.setState({
-      syncProgress: (walletBestBlockTimestamp - initialWalletBestBlockTimestamp) /
-        (Math.round((new Date()).getTime() / 1000) - initialWalletBestBlockTimestamp) * 100 
+      syncProgress: (bestHeaderTimestamp - initialBestHeaderTimestamp) /
+        (Math.round((new Date()).getTime() / 1000) - initialBestHeaderTimestamp) * 100 
     })
   }
 
@@ -122,7 +122,7 @@ export default withRouter(connect(
   state => ({
     serverRunning: store.getServerRunning(state),
     isSynced: store.getSyncedToChain(state),
-    walletBestBlockTimestamp: store.getWalletBestBlockTimestamp(state),
+    bestHeaderTimestamp: store.getBestHeaderTimestamp(state),
     blockHeight: store.getBlockHeight(state),
     pubkey: store.getAccountPubkey(state),
     currency: store.getCurrency(state),


### PR DESCRIPTION
This commit closes #10:

This update uses (the currently proposed) syncedHeight and blockHeight
from the gRPC interface to lnd to determine the percentage of
completion toward the chain sync.

While the chain is not fully synced, the Sidebar makes a request to
update the account every 1000ms so the progress display is reasonably
smooth without spamming the lnd. The progress is displayed as an
absolutely positioned div over the status div using a complementary
color.