### PR TITLE
Adding the ability to pass arguments in npm start to lnd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ You can run the app in development mode in lieu of using the packaged app:
 npm start
 ```
 
+You can pass extra arguments to be passed to lnd daemon (note the extra --):
+```
+npm run start -- --peerport=10019 --rpcport=10017 --datadir=test_lnd --logdir=test_lnd
+```
+
 In development mode, the app will look for an lnd.conf in the default location for your platform. See [`lnd.conf` details](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md#creating-an-lndconf-optional). A typical lnd.conf for running on simnet will look like the following:
 
 ```

--- a/apps/desktop/main.dev.js
+++ b/apps/desktop/main.dev.js
@@ -41,6 +41,7 @@ const runProcesses = (processes, logs) => {
         const filePath = path.join(__dirname, 'bin', plat, plat === 'win32' ? `${ proc.name }.exe` : proc.name)
 
         try {
+          console.log(proc.args)
           const instance = cp.spawn(filePath, proc.args)
           runningProcesses.push(instance)
           instance.stdout.on('data', data => logs.push(`${ proc.name }: ${ data }`))

--- a/apps/desktop/main.dev.js
+++ b/apps/desktop/main.dev.js
@@ -76,6 +76,11 @@ const processes = [
   },
 ]
 
+const appendArgumentsLnd = () => {
+  processes[0].args = processes[0].args.concat(process.argv.slice(process.argv.indexOf('--') + 1))
+}
+
+appendArgumentsLnd()
 runProcesses(processes, logs)
 
 let intervalId

--- a/apps/desktop/main.dev.js
+++ b/apps/desktop/main.dev.js
@@ -41,7 +41,6 @@ const runProcesses = (processes, logs) => {
         const filePath = path.join(__dirname, 'bin', plat, plat === 'win32' ? `${ proc.name }.exe` : proc.name)
 
         try {
-          console.log(proc.args)
           const instance = cp.spawn(filePath, proc.args)
           runningProcesses.push(instance)
           instance.stdout.on('data', data => logs.push(`${ proc.name }: ${ data }`))

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "package": "cross-env NODE_ENV=production node -r babel-register -r babel-polyfill scripts/package.js",
     "package-all": "npm run package -- --all",
-    "start": "node scripts/startup-message.js && concurrently --kill-others \"npm run start-electron\" \"npm run start-webpack\" -n \"electron,webpack\" -p name",
-    "start-electron": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./main.dev",
+    "start": "f() { node scripts/startup-message.js && concurrently --kill-others \"npm run start-electron -- $*\" \"npm run start-webpack\" -n \"electron,webpack\" -p name; }; f",
+    "start-electron": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./main.dev -- $*",
     "start-webpack": "cross-env NODE_ENV=development node -r babel-register scripts/dev-server.js",
     "install-grpc": "cd node_modules/grpc && git submodule update --init && npm run electron-build -- --target=1.4.6"
   },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,7 +11,7 @@
     "package": "cross-env NODE_ENV=production node -r babel-register -r babel-polyfill scripts/package.js",
     "package-all": "npm run package -- --all",
     "start": "f() { node scripts/startup-message.js && concurrently --kill-others \"npm run start-electron -- $*\" \"npm run start-webpack\" -n \"electron,webpack\" -p name; }; f",
-    "start-electron": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./main.dev -- $*",
+    "start-electron": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./main.dev --",
     "start-webpack": "cross-env NODE_ENV=development node -r babel-register scripts/dev-server.js",
     "install-grpc": "cd node_modules/grpc && git submodule update --init && npm run electron-build -- --target=1.4.6"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "publish": "lerna publish",
     "clean": "lerna clean",
     "reinstall": "npm run clean && npm install",
-    "start": "cd apps/desktop && npm start -s",
+    "start": "cd apps/desktop && npm start -s --",
     "setup": "npm install && npm run install-grpc",
     "package-electron": "cd apps/desktop && npm run package",
     "package-all-electron": "cd apps/desktop && npm run package-all",


### PR DESCRIPTION
The only workaround that I had to do is that you have to write extra -- to pass arguments, like:

npm run start -- --peerport=10019 --rpcport=10017 --datadir=test_lnd --logdir=test_lnd

Because that's the way npm can pass custom arguments in its scripts.

<img width="687" alt="screen shot 2017-12-12 at 21 03 52" src="https://user-images.githubusercontent.com/161360/33915154-927941be-df80-11e7-9fd1-6c0f43dc59a8.png">

Related to #95 