### PR TITLE
Better sanitizePaymentRequest

### DIFF
--- a/packages/lightning-core/helpers/paymentRequest.js
+++ b/packages/lightning-core/helpers/paymentRequest.js
@@ -5,5 +5,5 @@ export const decoratePaymentRequest = (pr) => {
 }
 
 export const sanitizePaymentRequest = (pr) => {
-  return pr.replace(prefix, '')
+  return pr.replace(/lightning:(\/\/)?/g, '')
 }

--- a/packages/lightning-core/helpers/paymentRequest.js
+++ b/packages/lightning-core/helpers/paymentRequest.js
@@ -4,6 +4,7 @@ export const decoratePaymentRequest = (pr) => {
   return prefix + pr
 }
 
+// Payment requests should start with either lightning: or lightning://
 export const sanitizePaymentRequest = (pr) => {
   return pr.replace(/lightning:(\/\/)?/g, '')
 }


### PR DESCRIPTION
Really simple but functional. I noticed that starblocks's payment invoice uses `lightning:` and not `lightning://` (the only one specified by the function) so I added support for that prefix too by using regex.