### PR TITLE
Fix Error Handling for 'GRPC Call Deferred, Server Still Starting'

### DIFF
--- a/packages/redux-grpc-middleware/index.js
+++ b/packages/redux-grpc-middleware/index.js
@@ -62,7 +62,7 @@ export default (opts = {}) => {
 
     if (!ready) {
       return new Promise((resolve, reject) =>
-        reject('GRPC Call Deferred, Server Still Starting'))
+        reject({ message: 'GRPC Call Deferred, Server Still Starting' }))
     }
 
     if (stream) {


### PR DESCRIPTION
First of all, thank you to everyone involved in the development of lightning.

This PR address a small error handling issue. Currently, the `'GRPC Call Deferred, Server Still Starting'` error is returning a string, however the callback function is expecting an object with a key of `message` (https://github.com/lightninglabs/lightning-app/blob/master/packages/lightning-core/accounts/reducer.js#L206). Because there is no `message` key, no notification is shown to the user in this circumstance and makes it seem like the app is frozen.