### PR TITLE
adding storybook to lightning-components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ main.js.map
 stats.json
 
 test_lnd
+.vscode/

--- a/packages/lightning-components/.storybook/config.js
+++ b/packages/lightning-components/.storybook/config.js
@@ -1,0 +1,9 @@
+import { configure } from '@kadira/storybook'
+
+const req = require.context('../', true, /\/story.jsx?$/)
+
+function loadStories() {
+  req.keys().forEach(filename => req(filename))
+}
+
+configure(loadStories, module)

--- a/packages/lightning-components/package.json
+++ b/packages/lightning-components/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "storybook": "node_modules/.bin/start-storybook -p 9001"
   },
   "author": "case <case@casesandberg.com>",
   "license": "MIT",
@@ -12,6 +13,7 @@
     "lodash": "^4.16.1",
     "qr-image": "^3.1.0",
     "react": "^15.3.2",
+    "react-dom": "^15.3.2",
     "react-router-dom": "^4.0.0",
     "reactcss": "^1.0.8"
   },


### PR DESCRIPTION
It seems as if someone had tried adding storybook to `lightning-components`, however did not finish the configuration. There were multiple `story.js` files in the repo, however no configuration was set. This PR adds storybook to `lightning-components` which will greatly ease development.

Note: Some stories are throwing react errors. Maybe should be fixed in a separate PR?