### PR TITLE
making sure dialog shows when closing an active channel

### DIFF
--- a/packages/lightning-core/accounts/ChannelListItem.js
+++ b/packages/lightning-core/accounts/ChannelListItem.js
@@ -107,7 +107,7 @@ export const ChannelListItem = ({ id, capacity, currency, localBalance, remoteBa
   }
 
   const showPopupOrClose = () =>
-    (active ? close({ channelPoint }) : onShowPopup(PROMPT))
+    (!active ? close({ channelPoint }) : onShowPopup(PROMPT))
   const menu = new Menu()
   menu.append(new MenuItem({ label: 'Close Channel', click() { showPopupOrClose() } }))
   const handleMenu = () => menu.popup(remote.getCurrentWindow())


### PR DESCRIPTION
Fixes #145 

Condition to show popup dialog was wrong. Now will show confirmation if the channel is active, and will not if the channel is inactive.