### PR TITLE
Pubkey to channel list, fixing bug with balances in pending channels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "files.autoSave": "off"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "files.autoSave": "off"
-}

--- a/packages/lightning-core/accounts/ChannelListItem.js
+++ b/packages/lightning-core/accounts/ChannelListItem.js
@@ -15,7 +15,7 @@ import { store } from 'lightning-store'
 const { Menu, MenuItem } = remote
 
 export const ChannelListItem = ({ id, capacity, currency, localBalance, remoteBalance,
-  active, status, hover, channelPoint, onShowPopup, onClosePopup, onCloseChannel,
+  active, status, hover, channelPoint, remotePubkey, onShowPopup, onClosePopup, onCloseChannel,
   onSuccess, onFetchChannels }) => {
   const pending = status === 'pending-open'
                || status === 'pending-closing'
@@ -72,6 +72,16 @@ export const ChannelListItem = ({ id, capacity, currency, localBalance, remoteBa
         height: 12,
         borderRadius: 2,
       },
+      pubkeyContainer: {
+        color: '#333',
+        marginBottom: 7,
+      },
+      pubkeyLabel: {
+        fontSize: 16,
+      },
+      pubkey: {
+        fontSize: 13,
+      },
     },
     'hover': {
       closeLabel: {
@@ -86,6 +96,9 @@ export const ChannelListItem = ({ id, capacity, currency, localBalance, remoteBa
         color: '#999',
       },
       remote: {
+        color: '#999',
+      },
+      pubkeyContainer: {
         color: '#999',
       },
       percent: {
@@ -143,7 +156,10 @@ export const ChannelListItem = ({ id, capacity, currency, localBalance, remoteBa
           { status }
         </div>
       </div>
-
+      <div style={ styles.pubkeyContainer }>
+        <span style={ styles.pubkeyLabel } >Pubkey: </span>
+        <span style={ styles.pubkey }>{ remotePubkey }</span>
+      </div>
       <div style={ styles.split }>
         <div style={ styles.local }>My Balance: <Money amount={ localBalance } currency={ currency } /> <MoneySign currency={ currency } /></div>
         <div style={ styles.remote }>Available to Receive: <Money amount={ remoteBalance } currency={ currency } /> <MoneySign currency={ currency } /></div>

--- a/packages/lightning-core/accounts/reducer.js
+++ b/packages/lightning-core/accounts/reducer.js
@@ -125,16 +125,16 @@ export const actions = {
       method: 'pendingChannels',
       types: [null, PENDING_CHANNELS, FETCH_CHANNELS_FAILURE],
       schema: (data) => {
-        const decorateChannels = (channels, transform) =>
+        const decorateChannels = (channels, transform) => (
           _.map(channels, channel => ({
-            remotePubkey: channel.remote_node_pub,
-            capacity: channel.capacity,
-            localBalance: channel.local_balance,
-            remoteBalance: channel.remote_balance,
-            channelPoint: channel.channel_point,
+            remotePubkey: channel.channel.remote_node_pub,
+            capacity: channel.channel.capacity,
+            localBalance: channel.channel.local_balance,
+            remoteBalance: channel.channel.remote_balance,
+            channelPoint: channel.channel.channel_point,
             ...transform(channel),
           }))
-
+        )
         return {
           pendingChannels: [
             ...decorateChannels(data.pending_open_channels, () => ({ status: 'pending-open' })),


### PR DESCRIPTION
Fixes #142 while also adding `remote_node_pub` to channels in channel list. I commonly found myself wondering which channels were which when testing, and think listing the public key will help.

Fixing bugs up as I find them.

![image](https://user-images.githubusercontent.com/3860450/35307968-607fccc8-0073-11e8-97e2-320e0fb89186.png)


