### PR TITLE
Add progress bar sync

### DIFF
--- a/src/actions/info.js
+++ b/src/actions/info.js
@@ -16,6 +16,10 @@ class ActionsInfo {
       this._store.pubKey = response.identity_pubkey;
       this._store.syncedToChain = response.synced_to_chain;
       this._store.blockHeight = response.block_height;
+      if (!response.synced_to_chain) {
+        clearTimeout(this.t3);
+        this.t3 = setTimeout(() => this.getInfo(), 1000);
+      }
     } catch (err) {
       clearTimeout(this.t3);
       this.t3 = setTimeout(() => this.getInfo(), RETRY_DELAY);

--- a/src/actions/info.js
+++ b/src/actions/info.js
@@ -18,7 +18,7 @@ class ActionsInfo {
       this._store.blockHeight = response.block_height;
       if (!response.synced_to_chain) {
         clearTimeout(this.t3);
-        this.t3 = setTimeout(() => this.getInfo(), 1000);
+        this.t3 = setTimeout(() => this.getInfo(), RETRY_DELAY);
       }
     } catch (err) {
       clearTimeout(this.t3);

--- a/src/actions/info.js
+++ b/src/actions/info.js
@@ -14,6 +14,8 @@ class ActionsInfo {
     try {
       const response = await this._actionsGrpc.sendCommand('getInfo');
       this._store.pubKey = response.identity_pubkey;
+      this._store.syncedToChain = response.synced_to_chain;
+      this._store.blockHeight = response.block_height;
     } catch (err) {
       clearTimeout(this.t3);
       this.t3 = setTimeout(() => this.getInfo(), RETRY_DELAY);

--- a/src/store.js
+++ b/src/store.js
@@ -11,8 +11,10 @@ class Store {
     extendObservable(this, {
       loaded: false, // Is persistent data loaded
       lndReady: false, // Is lnd process running
+      syncedToChain: false, // Is lnd synced to blockchain
       route: DEFAULT_ROUTE,
 
+      blockHeight: null,
       balanceSatoshis: null,
       confirmedBalanceSatoshis: null,
       unconfirmedBalanceSatoshis: null,

--- a/src/views/sidebar.js
+++ b/src/views/sidebar.js
@@ -1,14 +1,27 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 
-import { actionsNav } from '../actions';
+import { actionsNav, actionsInfo } from '../actions';
 import ComponentIcon from '../components/icon';
 import Text from '../components/text';
 import { colors } from '../styles';
 import { View, TouchableOpacity } from 'react-native';
 import store from '../store';
 
+let interval;
+
 class Sidebar extends Component {
+  componentDidMount() {
+    interval = setInterval(() => {
+      actionsInfo.getInfo();
+      if (actionsInfo._store.syncedToChain) clearInterval(interval);
+    }, 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(interval);
+  }
+
   renderRow(name, icon, onPress) {
     const { route } = store;
     const color = route === name ? colors.blue : colors.gray;
@@ -32,7 +45,7 @@ class Sidebar extends Component {
   }
 
   render() {
-    const { computedBalance, pubKey } = store;
+    const { computedBalance, pubKey, syncedToChain, blockHeight } = store;
     return (
       <View style={{ width: 170, backgroundColor: colors.sidebar }}>
         {this.renderRow('Pay', 'coin', () => actionsNav.goPay())}
@@ -70,6 +83,42 @@ class Sidebar extends Component {
             {pubKey}
           </Text>
         </TouchableOpacity>
+        {syncedToChain ? null : (
+          <div
+            style={{
+              padding: 10,
+              paddingBottom: 12,
+              textAlign: 'center',
+              backgroundColor: colors.blue,
+            }}
+            className="syncing"
+          >
+            <style
+              dangerouslySetInnerHTML={{
+                __html: `
+                 .syncing {
+                   animation: pulse 1.5s 100ms ease-in-out infinite alternate;
+                 }
+                 @keyframes pulse {
+                   0% { opacity: 1 }
+                   50% { opacity: 0.8 }
+                   100% { opacity: 1 }
+                 }`,
+              }}
+            />
+            Syncing to Chain
+            <span
+              style={{
+                fontSize: 8,
+                position: 'absolute',
+                bottom: '2px',
+                right: '2px',
+              }}
+            >
+              {`Block Height: ${blockHeight}`}
+            </span>
+          </div>
+        )}
       </View>
     );
   }

--- a/src/views/sidebar.js
+++ b/src/views/sidebar.js
@@ -1,17 +1,14 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 
-import { actionsNav, actionsInfo } from '../actions';
+import { actionsNav } from '../actions';
 import ComponentIcon from '../components/icon';
 import Text from '../components/text';
 import { colors } from '../styles';
 import { View, TouchableOpacity } from 'react-native';
 import store from '../store';
 
-let interval;
-
 class Sidebar extends Component {
-
   renderRow(name, icon, onPress) {
     const { route } = store;
     const color = route === name ? colors.blue : colors.gray;

--- a/src/views/sidebar.js
+++ b/src/views/sidebar.js
@@ -11,16 +11,6 @@ import store from '../store';
 let interval;
 
 class Sidebar extends Component {
-  componentDidMount() {
-    interval = setInterval(() => {
-      actionsInfo.getInfo();
-      if (actionsInfo._store.syncedToChain) clearInterval(interval);
-    }, 1000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(interval);
-  }
 
   renderRow(name, icon, onPress) {
     const { route } = store;
@@ -45,6 +35,13 @@ class Sidebar extends Component {
   }
 
   render() {
+    let styleSheet = document.styleSheets[0];
+    let keyframes = `@keyframes pulse {
+                    0% { opacity: 1 }
+                    50% { opacity: 0.8 }
+                    100% { opacity: 1 }
+                  }`;
+    styleSheet.insertRule(keyframes, styleSheet.cssRules.length);
     const { computedBalance, pubKey, syncedToChain, blockHeight } = store;
     return (
       <View style={{ width: 170, backgroundColor: colors.sidebar }}>
@@ -90,22 +87,15 @@ class Sidebar extends Component {
               paddingBottom: 12,
               textAlign: 'center',
               backgroundColor: colors.blue,
+              animationName: 'pulse',
+              animationTimingFunction: 'ease-in-out',
+              animationDuration: '1.5s',
+              animationDelay: '0.0s',
+              animationIterationCount: 'infinite',
+              animationDirection: 'alternate',
             }}
             className="syncing"
           >
-            <style
-              dangerouslySetInnerHTML={{
-                __html: `
-                 .syncing {
-                   animation: pulse 1.5s 100ms ease-in-out infinite alternate;
-                 }
-                 @keyframes pulse {
-                   0% { opacity: 1 }
-                   50% { opacity: 0.8 }
-                   100% { opacity: 1 }
-                 }`,
-              }}
-            />
             Syncing to Chain
             <span
               style={{
@@ -115,7 +105,7 @@ class Sidebar extends Component {
                 right: '2px',
               }}
             >
-              {`Block Height: ${blockHeight}`}
+              {`Block Height: ${blockHeight || 'loading'}`}
             </span>
           </div>
         )}


### PR DESCRIPTION
Ported the progress bar for chain sync to v2. It updates user w/ the current block height. Once the chain is synced, the progress bar disappears.

Kept with the current code style with inline css.

Closes #188 

## Overall View
<img width="1440" alt="screen shot 2018-02-04 at 5 41 05 pm" src="https://user-images.githubusercontent.com/16689974/35785213-afc2185e-09d3-11e8-9b22-07457c7dff0d.png">

## Close up
<img width="172" alt="screen shot 2018-02-04 at 5 41 10 pm" src="https://user-images.githubusercontent.com/16689974/35785227-bb57bc78-09d3-11e8-9c49-30fbbe7e1668.png">

## GIF w/ updating block height and v1 animation
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/16689974/35785289-3867add6-09d4-11e8-8fc4-0093fba4201e.gif)


