### PR TITLE
Use btcsuite/btcd in integration tests

### DIFF
--- a/assets/script/install_lnd.sh
+++ b/assets/script/install_lnd.sh
@@ -2,7 +2,6 @@
 
 # versions
 GO_TAG=1.10.2
-GLIDE_TAG=0.12.3
 
 # install go
 GO_DOWNLOAD="https://storage.googleapis.com/golang/go$GO_TAG.linux-amd64.tar.gz"
@@ -18,9 +17,7 @@ export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 go get -u github.com/golang/dep/cmd/dep
 
 # install glide
-GLIDE_DOWNLOAD="https://github.com/Masterminds/glide/releases/download/v$GLIDE_TAG/glide-v$GLIDE_TAG-linux-amd64.tar.gz"
-curl -L $GLIDE_DOWNLOAD | tar -xz
-export PATH=$PWD/linux-amd64/:$PATH
+go get -u github.com/Masterminds/glide
 
 # install lnd
 git clone https://github.com/lightningnetwork/lnd $GOPATH/src/github.com/lightningnetwork/lnd
@@ -28,8 +25,8 @@ cd $GOPATH/src/github.com/lightningnetwork/lnd
 make && make install
 
 # install btcd
-git clone https://github.com/roasbeef/btcd $GOPATH/src/github.com/roasbeef/btcd
-cd $GOPATH/src/github.com/roasbeef/btcd
+git clone https://github.com/btcsuite/btcd $GOPATH/src/github.com/btcsuite/btcd
+cd $GOPATH/src/github.com/btcsuite/btcd
 glide install
 go install . ./cmd/...
 


### PR DESCRIPTION
@valentinewallace I hope this makes the integration tests more reliable. Not sure why the builds are breaking. See linked issue below...

Closes #356 