### PR TITLE
Fix broken Linux/Windows builds on travis

### DIFF
--- a/assets/script/build_app.sh
+++ b/assets/script/build_app.sh
@@ -18,6 +18,7 @@ else
   env | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS_TAG|TRAVIS|TRAVIS_REPO_|TRAVIS_BUILD_|TRAVIS_BRANCH|TRAVIS_PULL_REQUEST_|APPVEYOR_|CSC_|GH_|GITHUB_|BT_|AWS_|STRIP|BUILD_' > env.txt
   docker run --rm \
     --env-file env.txt \
+    --env HOME="/project" \
     --env ELECTRON_CACHE="/root/.cache/electron" \
     --env DEBUG=electron-builder \
     --env ELECTRON_BUILDER_CACHE="/root/.cache/electron-builder" \
@@ -26,6 +27,7 @@ else
     -v ~/.cache/electron:/root/.cache/electron \
     -v ~/.cache/electron-builder:/root/.cache/electron-builder \
     electronuserland/builder:wine \
-    /bin/bash -c "npm i && npm run electron-pack -- --win -c.npmArgs=--target-libc=unknown && npm run electron-pack -- --linux"
+    /bin/bash -c "chown -R root:root /project && npm i && npm run electron-pack -- --win -c.npmArgs=--target-libc=unknown && npm run electron-pack -- --linux"
+  sudo chown -R travis:travis ./
   rm env.txt
 fi


### PR DESCRIPTION
Closes #427 
For some reason, the docker `$HOME` var was set as `/home/travis` [nonexistent] which caused the original failure. 

Additionally, `wine` didn't have permission to add to docker's `/project`directory, necessitating `chown`ing the directory before wine is able to add any artifacts to it. 