### PR TITLE
White list IPC events

### DIFF
--- a/public/preload.js
+++ b/public/preload.js
@@ -1,2 +1,24 @@
-// expose only ipcRenderer to sandbox instead of all node apis
-window.ipcRenderer = require('electron').ipcRenderer;
+/**
+ * @fileOverview exposes only required apis to rendering process to minimize attack surface
+ */
+
+const _ipcRenderer = require('electron').ipcRenderer;
+
+const filter = event => {
+  if (!/^(lnd)|(unlock)[a-zA-Z_]{20}$/.test(event)) {
+    throw new Error('Invalid IPC');
+  }
+  return event;
+};
+
+window.ipcRenderer = {
+  send: (event, data) => {
+    _ipcRenderer.send(filter(event), data);
+  },
+  on: (event, callback) => {
+    _ipcRenderer.on(filter(event), callback);
+  },
+  once: (event, callback) => {
+    _ipcRenderer.once(filter(event), callback);
+  },
+};

--- a/public/preload.js
+++ b/public/preload.js
@@ -5,8 +5,8 @@
 const _ipcRenderer = require('electron').ipcRenderer;
 
 const filter = event => {
-  if (!/^(lnd)|(unlock)[a-zA-Z_]{20}$/.test(event)) {
-    throw new Error('Invalid IPC');
+  if (!/^(lnd)|(unlock)|(log)|(open-url)[a-zA-Z_-]{0,20}$/.test(event)) {
+    throw new Error(`Invalid IPC: ${event}`);
   }
   return event;
 };


### PR DESCRIPTION
Closes #75 

@kewde this removes direct access to `ipcRenderer` from the rendering process. Does this make sense or would you recommend further mitigation?