### PR TITLE
Implement Wait screen redesign

### DIFF
--- a/src/component/spinner.js
+++ b/src/component/spinner.js
@@ -77,9 +77,11 @@ export class ContinuousLoadNetworkSpinner extends Component {
       percentage: 0,
     };
   }
+
   componentDidMount() {
     this.intervalId = setInterval(this.increasePercentage, 10);
   }
+
   render() {
     const { msg, style } = this.props;
     const { percentage } = this.state;
@@ -92,12 +94,14 @@ export class ContinuousLoadNetworkSpinner extends Component {
       />
     );
   }
+
   increasePercentage() {
     const { percentage } = this.state;
     this.setState({
       percentage: (percentage + 0.01) % 1,
     });
   }
+
   componentWillUnmount() {
     clearInterval(this.intervalId);
   }
@@ -222,6 +226,20 @@ SpinnerFill.propTypes = {
   color: PropTypes.string.isRequired,
 };
 
+/**
+ * @typedef {Object} Point
+ * @property {number} x The X Coordinate
+ * @property {number} y The Y Coordinate
+ */
+
+/**
+ * Translate radius + angle information into cartestian x and y
+ * @param  {number} centerX        The X-coord of the center of the circle
+ * @param  {number} centerY        The Y-coord of the center of the circle
+ * @param  {number} radius         The radius of the circle
+ * @param  {number} angleInDegrees The angle at which the point sits
+ * @return {Point}                 The point in cartesian form
+ */
 const polarToCartesian = (centerX, centerY, radius, angleInDegrees) => {
   const angleInRadians = (angleInDegrees - 90) * Math.PI / 180.0;
 
@@ -231,6 +249,15 @@ const polarToCartesian = (centerX, centerY, radius, angleInDegrees) => {
   };
 };
 
+/**
+ * Create an SVG path string for a circular arc
+ * @param  {number} x          The X-coord of the center of the circle
+ * @param  {number} y          The Y-coord of the center of the circle
+ * @param  {number} radius     The radius of the circle
+ * @param  {number} startAngle The angle at which to start the arc
+ * @param  {number} endAngle   The angle at which to end the arc
+ * @return {string}            The path string for the arc
+ */
 const generateArc = (x, y, radius, startAngle, endAngle) => {
   const start = polarToCartesian(x, y, radius, endAngle);
   const end = polarToCartesian(x, y, radius, startAngle);

--- a/src/component/spinner.js
+++ b/src/component/spinner.js
@@ -43,9 +43,10 @@ const loadNetworkStyles = StyleSheet.create({
   },
 });
 
-export const LoadNetworkSpinner = ({ percentage, msg, style }) => (
+export const LoadNetworkSpinner = ({ continuous, percentage, msg, style }) => (
   <View style={style}>
     <ResizeableSpinner
+      continuous={continuous}
       percentage={percentage}
       size={80}
       progressWidth={4}
@@ -58,6 +59,7 @@ export const LoadNetworkSpinner = ({ percentage, msg, style }) => (
 );
 
 LoadNetworkSpinner.propTypes = {
+  continuous: PropTypes.bool,
   percentage: PropTypes.number.isRequired,
   msg: PropTypes.string.isRequired,
   style: View.propTypes.style,
@@ -81,7 +83,12 @@ export class ContinuousLoadNetworkSpinner extends Component {
     const { msg, style } = this.props;
     const { percentage } = this.state;
     return (
-      <LoadNetworkSpinner msg={msg} percentage={percentage} style={style} />
+      <LoadNetworkSpinner
+        msg={msg}
+        percentage={percentage}
+        style={style}
+        continuous={true}
+      />
     );
   }
   increasePercentage() {
@@ -117,6 +124,7 @@ const resizeableStyles = StyleSheet.create({
 });
 
 export const ResizeableSpinner = ({
+  continuous,
   percentage,
   size,
   gradient,
@@ -127,6 +135,7 @@ export const ResizeableSpinner = ({
     <Svg width={size} height={size}>
       <Gradients />
       <SpinnerProgress
+        continuous={continuous}
         width={size}
         percentage={percentage}
         color={`url(#${gradient})`}
@@ -142,6 +151,7 @@ export const ResizeableSpinner = ({
 );
 
 ResizeableSpinner.propTypes = {
+  continuous: PropTypes.bool,
   percentage: PropTypes.number.isRequired,
   size: PropTypes.number.isRequired,
   progressWidth: PropTypes.number.isRequired,
@@ -172,20 +182,21 @@ const Gradients = () => (
 // Spinner Progress Path
 //
 
-const SpinnerProgress = ({ width, percentage, color }) => (
+const SpinnerProgress = ({ continuous, width, percentage, color }) => (
   <Path
     d={generateArc(
       width / 2,
       width / 2,
       width / 2,
-      percentage * 360,
-      ((percentage + 0.4) % 1) * 360
+      continuous ? percentage * 360 : 0,
+      continuous ? ((percentage + 0.4) % 1) * 360 : percentage * 360
     )}
     fill={color}
   />
 );
 
 SpinnerProgress.propTypes = {
+  continuous: PropTypes.bool,
   width: PropTypes.number.isRequired,
   percentage: PropTypes.number.isRequired,
   color: PropTypes.string.isRequired,
@@ -226,7 +237,8 @@ const generateArc = (x, y, radius, startAngle, endAngle) => {
   const largeArcFlag = endAngle - startAngle <= 180 ? '0' : '1';
 
   return [
-    `M ${start.x} ${start.y}`,
+    `M ${x} ${y}`,
+    `L ${start.x} ${start.y}`,
     `A ${radius} ${radius} 0 ${largeArcFlag} 0 ${end.x} ${end.y}`,
     'Z',
   ].join(' ');

--- a/src/component/spinner.js
+++ b/src/component/spinner.js
@@ -49,7 +49,7 @@ export const LoadNetworkSpinner = ({ continuous, percentage, msg, style }) => (
       continuous={continuous}
       percentage={percentage}
       size={80}
-      progressWidth={4}
+      progressWidth={3}
       gradient="loadNetworkGrad"
     >
       <LightningBoltIcon height={28} width={14.2222} />
@@ -190,7 +190,7 @@ const SpinnerProgress = ({ continuous, width, percentage, color }) => (
       width / 2,
       width / 2,
       continuous ? percentage * 360 : 0,
-      continuous ? ((percentage + 0.4) % 1) * 360 : percentage * 360
+      continuous ? (percentage + 0.4) * 360 : percentage * 360
     )}
     fill={color}
   />

--- a/src/component/spinner.js
+++ b/src/component/spinner.js
@@ -73,11 +73,12 @@ export class ContinuousLoadNetworkSpinner extends Component {
   constructor(props) {
     super(props);
     this.increasePercentage = this.increasePercentage.bind(this);
-    const intervalId = setInterval(this.increasePercentage, 10);
     this.state = {
       percentage: 0,
-      intervalId,
     };
+  }
+  componentDidMount() {
+    this.intervalId = setInterval(this.increasePercentage, 10);
   }
   render() {
     const { msg, style } = this.props;
@@ -98,7 +99,7 @@ export class ContinuousLoadNetworkSpinner extends Component {
     });
   }
   componentWillUnmount() {
-    clearInterval(this.state.intervalId);
+    clearInterval(this.intervalId);
   }
 }
 

--- a/src/view/wait.js
+++ b/src/view/wait.js
@@ -1,26 +1,20 @@
 import React from 'react';
-import { StyleSheet, ActivityIndicator } from 'react-native';
+import { StyleSheet } from 'react-native';
 import Background from '../component/background';
 import MainContent from '../component/main-content';
 import { color } from '../component/style';
+import { ContinuousLoadNetworkSpinner } from '../component/spinner';
 
 const styles = StyleSheet.create({
   content: {
     justifyContent: 'center',
-  },
-  spinner: {
-    transform: [{ scale: 1.5 }],
   },
 });
 
 const WaitView = () => (
   <Background color={color.blackDark}>
     <MainContent style={styles.content}>
-      <ActivityIndicator
-        size="large"
-        color={color.lightPurple}
-        style={styles.spinner}
-      />
+      <ContinuousLoadNetworkSpinner msg="Loading network..." />
     </MainContent>
   </Background>
 );

--- a/stories/component/spinner.js
+++ b/stories/component/spinner.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import MainContent from '../../src/component/main-content';
-import { SmallSpinner, LoadNetworkSpinner } from '../../src/component/spinner';
+import {
+  SmallSpinner,
+  LoadNetworkSpinner,
+  ContinuousLoadNetworkSpinner,
+} from '../../src/component/spinner';
 import { color } from '../../src/component/style';
 import Background from '../../src/component/background';
 
@@ -32,5 +36,10 @@ storiesOf('Spinner', module)
         msg="Just a few seconds..."
         style={{ margin: 20 }}
       />
+    </MainContent>
+  ))
+  .add('Continuous Load Network Spinner', () => (
+    <MainContent style={{ justifyContent: 'center' }}>
+      <ContinuousLoadNetworkSpinner msg="Loading network..." />
     </MainContent>
   ));


### PR DESCRIPTION
Addresses #466 

It doesn't seem like there are many hooks that we can listen to in order to make the spinner accurately depict progress - AFAIK the app is just issuing a `UnlockWallet` grpc command and waiting for a `lndReady` event, or something very similar.

This is why I created a continuous spinner

![qcsk15df1k](https://user-images.githubusercontent.com/2482470/43311647-43b16172-9148-11e8-86c5-3a1077665165.gif)

Don't worry, the animation is smooth when not in gif format.