### PR TITLE
Add assets/bin to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn.lock
 /dist
 /data
 /test/data
+/assets/bin


### PR DESCRIPTION
Following the "build packaged app" from README includes `cp
$GOPATH/bin/lnd ./assets/bin/darwin` which will create an untracked
`assets/bin/darwin/lnd`.