### PR TITLE
Adds the preimage to off-chain payments completed

### DIFF
--- a/src/action/transaction.js
+++ b/src/action/transaction.js
@@ -112,6 +112,7 @@ class TransactionAction {
         status: 'complete',
         date: parseDate(payment.creation_date),
         hash: payment.payment_hash,
+        preimage: payment.payment_preimage,
       }));
     } catch (err) {
       log.error('Listing payments failed', err);

--- a/src/view/transaction-detail.js
+++ b/src/view/transaction-detail.js
@@ -36,6 +36,11 @@ const TransactionDetailView = ({ store, nav }) => (
         <DetailField name="Fee">
           {store.selectedTransaction.feeLabel} {store.unitLabel}
         </DetailField>
+        {store.selectedTransaction.preimage ? (
+          <DetailField name="Proof of payment">
+            {store.selectedTransaction.preimage}
+          </DetailField>
+        ) : null}
         {store.selectedTransaction.confirmationsLabel ? (
           <DetailField name="Confirmations">
             {store.selectedTransaction.confirmationsLabel}


### PR DESCRIPTION
When the user pays an invoice needs to know the preimage as a proof of payment, currently it's not showing this field on transaction detail modal.

https://github.com/lightninglabs/lightning-app/issues/494