### PR TITLE
Switch from killing lnd process on app close to using StopDaemon RPC …

### DIFF
--- a/public/preload.js
+++ b/public/preload.js
@@ -24,3 +24,5 @@ window.ipcRenderer = {
     _ipcRenderer.once(filter(event), callback);
   },
 };
+
+_ipcRenderer.on('app-close', () => _ipcRenderer.send('app-close'));

--- a/test/integration/action/action-integration.spec.js
+++ b/test/integration/action/action-integration.spec.js
@@ -20,7 +20,7 @@ const {
   startBtcdProcess,
   mineBlocks,
 } = require('../../../public/lnd-child-process');
-const grcpClient = require('../../../public/grpc-client');
+const grpcClient = require('../../../public/grpc-client');
 
 /* eslint-disable no-unused-vars */
 
@@ -129,13 +129,13 @@ describe('Action Integration Tests', function() {
     lndProcess1 = await lndProcess1Promise;
     lndProcess2 = await lndProcess2Promise;
 
-    await grcpClient.init({
+    await grpcClient.init({
       ipcMain: ipcMainStub1,
       lndPort: LND_PORT_1,
       lndSettingsDir: LND_SETTINGS_DIR_1,
       network: NETWORK,
     });
-    await grcpClient.init({
+    await grpcClient.init({
       ipcMain: ipcMainStub2,
       lndPort: LND_PORT_2,
       lndSettingsDir: LND_SETTINGS_DIR_2,


### PR DESCRIPTION
…command

This prevents loss of user data by ensuring safe shutdown of the daemon.

This functionality doesn't work perfectly and improved functionality is waiting on a few changes to be merged into `lnd`. Users will need to use `ctrl-c` to quit the app if the RPC call is not available at the time of app close. 