### PR TITLE
Support bech32 addresses which is max 90 chars long

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -228,7 +228,7 @@ export const isLnUri = str => {
  * @return {boolean}     If the uri is valid
  */
 export const isAddress = str => {
-  return /^[a-km-zA-HJ-NP-Z0-9]{26,35}$/.test(str);
+  return /^[a-km-zA-HJ-NP-Z0-9]{26,90}$/.test(str);
 };
 
 /**

--- a/test/unit/helper.spec.js
+++ b/test/unit/helper.spec.js
@@ -721,12 +721,18 @@ describe('Helpers Unit Tests', () => {
   });
 
   describe('isAddress()', () => {
-    it('should accept bitcoin uri', () => {
+    it('should accept bitcoin address', () => {
       const address = 'rfu4i1Mo2NF7TQsN9bMVLFSojSzcyQCEH5';
       expect(helpers.isAddress(address), 'to be', true);
     });
 
-    it('should reject invalid bitcoin uri', () => {
+    it('should accept bech32 address', () => {
+      const address =
+        'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
+      expect(helpers.isAddress(address), 'to be', true);
+    });
+
+    it('should reject invalid bitcoin address', () => {
       const address = '/INVALID/rfu4i1Mo2NF7TQsN9bMVLFSoj';
       expect(helpers.isAddress(address), 'to be', false);
     });


### PR DESCRIPTION
See: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32

Closes #616 

Good catch @alexbosworth 