### PR TITLE
Safely shutdown lnd with SIGINT.

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -195,7 +195,7 @@ app.on('activate', () => {
 });
 
 app.on('quit', () => {
-  lndProcess && lndProcess.kill();
+  lndProcess && lndProcess.kill('SIGINT');
   btcdProcess && btcdProcess.kill();
 });
 

--- a/public/electron.js
+++ b/public/electron.js
@@ -196,7 +196,7 @@ app.on('activate', () => {
 
 app.on('quit', () => {
   lndProcess && lndProcess.kill('SIGINT');
-  btcdProcess && btcdProcess.kill();
+  btcdProcess && btcdProcess.kill('SIGINT');
 });
 
 app.setAsDefaultProtocolClient(PREFIX_NAME);

--- a/test/integration/action/action-integration.spec.js
+++ b/test/integration/action/action-integration.spec.js
@@ -169,8 +169,8 @@ describe('Action Integration Tests', function() {
 
   after(async () => {
     await Promise.all([grpc1.closeLnd(), grpc2.closeLnd()]);
-    lndProcess1.kill();
-    lndProcess2.kill();
+    lndProcess1.kill('SIGINT');
+    lndProcess2.kill('SIGINT');
     btcdProcess.kill();
   });
 

--- a/test/integration/action/action-integration.spec.js
+++ b/test/integration/action/action-integration.spec.js
@@ -171,7 +171,7 @@ describe('Action Integration Tests', function() {
     await Promise.all([grpc1.closeLnd(), grpc2.closeLnd()]);
     lndProcess1.kill('SIGINT');
     lndProcess2.kill('SIGINT');
-    btcdProcess.kill();
+    btcdProcess.kill('SIGINT');
   });
 
   describe('Generate seed and unlock wallet', () => {
@@ -223,7 +223,7 @@ describe('Action Integration Tests', function() {
     });
 
     it('should fund wallet for node1', async () => {
-      btcdProcess.kill();
+      btcdProcess.kill('SIGINT');
       btcdArgs.miningAddress = store1.walletAddress;
       btcdProcess = await startBtcdProcess(btcdArgs);
       await nap(NAP_TIME);


### PR DESCRIPTION
Replaces #564, closes #550. 

@erkarl This consistently works for me to safely shutdown the daemon, is there a reason you wanted to send the signal in the `before-quit` event? 
