### PR TITLE
Fix windows binary build

### DIFF
--- a/assets/script/build_app.sh
+++ b/assets/script/build_app.sh
@@ -10,7 +10,7 @@ if [ "$(uname)" == "Darwin" ]; then
 else
   # build binaries for windows
   cd assets/bin/win32
-  env GOOS="windows" GOARCH="386" go build -v github.com/lightningnetwork/lnd
+  env GOOS="windows" GOARCH="386" go build -v -tags="experimental" github.com/lightningnetwork/lnd
   env GOOS="windows" GOARCH="386" go build -v github.com/btcsuite/btcd
 
   # build the packages using electron-builder on docker


### PR DESCRIPTION
Adds "experimental" tag to the windows binary build so that it
recognizes the `routing.assumechanvalid` flag.

After building the binary with the updated script my windows 10 test machine is now nicely syncing to the chain.

Closes https://github.com/lightninglabs/lightning-app/issues/631