### PR TITLE
Revert "Fix windows binary build"

### DIFF
--- a/assets/script/build_app.sh
+++ b/assets/script/build_app.sh
@@ -10,7 +10,7 @@ if [ "$(uname)" == "Darwin" ]; then
 else
   # build binaries for windows
   cd assets/bin/win32
-  env GOOS="windows" GOARCH="386" go build -v -tags="experimental" github.com/lightningnetwork/lnd
+  env GOOS="windows" GOARCH="386" go build -v github.com/lightningnetwork/lnd
   env GOOS="windows" GOARCH="386" go build -v github.com/btcsuite/btcd
 
   # build the packages using electron-builder on docker


### PR DESCRIPTION
Reverts lightninglabs/lightning-app#632

@erkarl did you test the script? Seems like this broke the Windows build

<img width="1008" alt="bildschirmfoto 2018-09-07 um 17 27 23" src="https://user-images.githubusercontent.com/1374174/45228410-65bc3480-b2c3-11e8-9578-75fc1e9121ef.png">
