### PR TITLE
Limit transactions list to last 100 transactions

### DIFF
--- a/src/computed/transaction.js
+++ b/src/computed/transaction.js
@@ -28,7 +28,7 @@ const ComputedTransaction = store => {
           t.confirmationsLabel = t.confirmations.toString();
         }
       });
-      return all;
+      return all.slice(0, 100);
     }),
   });
 };

--- a/test/unit/computed/transaction.spec.js
+++ b/test/unit/computed/transaction.spec.js
@@ -3,18 +3,19 @@ import ComputedTransaction from '../../../src/computed/transaction';
 
 describe('Computed Transactions Unit Tests', () => {
   let store;
+  const bitcoinTransaction = {
+    id: '0',
+    type: 'bitcoin',
+    amount: 923456,
+    fee: 8250,
+    confirmations: 0,
+    status: 'unconfirmed',
+    date: new Date(),
+  };
 
   beforeEach(() => {
     store = new Store();
-    store.transactions.push({
-      id: '0',
-      type: 'bitcoin',
-      amount: 923456,
-      fee: 8250,
-      confirmations: 0,
-      status: 'unconfirmed',
-      date: new Date(),
-    });
+    store.transactions.push(bitcoinTransaction);
     store.payments.push({
       id: '1',
       type: 'lightning',
@@ -67,6 +68,18 @@ describe('Computed Transactions Unit Tests', () => {
       const tx = store.computedTransactions.find(t => t.id === '0');
       expect(tx.amountLabel, 'to match', /63[,.]67/);
       expect(tx.feeLabel, 'to match', /0[,.]57/);
+    });
+
+    it('should limit transactions to last 100', () => {
+      store.payments = null;
+      store.invoices = null;
+      store.transactions = [];
+      const TRANSACTIONS_COUNT = 101;
+      [...Array(TRANSACTIONS_COUNT)].forEach(() =>
+        store.transactions.push(bitcoinTransaction)
+      );
+      ComputedTransaction(store);
+      expect(store.computedTransactions.length, 'to equal', 100);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/lightninglabs/lightning-app/issues/544

This PR mitigates the performance issue when there are lots of computed transactions in the transactions list.

![screen shot 2018-09-10 at 14 15 07](https://user-images.githubusercontent.com/1056569/45294605-95a64a80-b504-11e8-83df-fff640033dd7.png)

The app still feels a little janky/sluggish (~800ms frame), but it's definitely an improvement and quick win over the previous result (~2000ms).