### PR TITLE
Update README with bitcoind setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ To run the packaged version of the app e.g. for macOS run:
 
 ### Starting the Packaged App (full node)
 
+#### btcd
 Start btcd in a seperate terminal session and wait until it's fully synced (can take over a day)
 ```
 btcd --testnet --txindex --rpcuser=kek --rpcpass=kek
@@ -71,6 +72,16 @@ To run the packaged version of the app e.g. for macOS run:
 ./dist/mac/Lightning.app/Contents/MacOS/Lightning --btcd.rpcuser=kek --btcd.rpcpass=kek
 ```
 
+#### bitcoind
+Start bitcoind in a seperate terminal session and wait until it's fully synced (can take over a day)
+```
+bitcoind -testnet -txindex=1 -rpcuser=kek -rpcpassword=kek -rpcbind=localhost -zmqpubrawblock=tcp://127.0.0.1:28332 -zmqpubrawtx=tcp://127.0.0.1:28333
+```
+
+To run the packaged version of the app e.g. for macOS run:
+```
+./dist/mac/Lightning.app/Contents/MacOS/Lightning --bitcoin.node=bitcoind --bitcoind.rpcuser=kek --bitcoind.rpcpass=kek --bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332 --bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
+```
 
 ### Lnd data and logs
 Lnd data and logs are written to the following locations in production:


### PR DESCRIPTION
This PR updates the README to include instructions on how to connect bitcoind full node.

Not sure if we need the `-txindex=1` flag any longer ([related LND PR](https://github.com/lightningnetwork/lnd/pull/751)), but since I already had a testnet node with `txindex` enabled I went with that. Was able to sync, fund the wallet and channels just fine.

Closes https://github.com/lightninglabs/lightning-app/issues/662