### PR TITLE
Add support for Windows lightning links

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -204,7 +204,11 @@ app.on('quit', () => {
 });
 
 // Prevent multiple instances of the application.
-const duplicateInstance = app.makeSingleInstance(() => {
+const duplicateInstance = app.makeSingleInstance(args => {
+  if (process.platform == 'win32') {
+    const protocolUrl = args && args.slice(1)[0];
+    if (protocolUrl) onOpenUrl(null, protocolUrl);
+  }
   if (win) {
     if (win.isMinimized()) win.restore();
     win.focus();
@@ -213,12 +217,13 @@ const duplicateInstance = app.makeSingleInstance(() => {
 if (duplicateInstance) app.quit();
 
 app.setAsDefaultProtocolClient(PREFIX_NAME);
-app.on('open-url', async (event, url) => {
+const onOpenUrl = async (event, url) => {
   while (!win) {
     await new Promise(resolve => setTimeout(resolve, LND_INIT_DELAY));
   }
   win && win.webContents.send('open-url', url);
-});
+};
+app.on('open-url', onOpenUrl);
 
 process.on('uncaughtException', error => {
   Logger.error('Caught Main Process Error:', error);

--- a/public/electron.js
+++ b/public/electron.js
@@ -203,6 +203,15 @@ app.on('quit', () => {
   btcdProcess && btcdProcess.kill('SIGINT');
 });
 
+// Prevent multiple instances of the application.
+const duplicateInstance = app.makeSingleInstance(() => {
+  if (win) {
+    if (win.isMinimized()) win.restore();
+    win.focus();
+  }
+});
+if (duplicateInstance) app.quit();
+
 app.setAsDefaultProtocolClient(PREFIX_NAME);
 app.on('open-url', async (event, url) => {
   while (!win) {


### PR DESCRIPTION
In this PR we:
* Restrict the application to run in a single instance mode. If the user tries to run the second instance we close the 2nd instance and focus the running application.
* Add additional logic to catch the protocol (`lightning:invoice`) links on Windows since it doesn't trigger the `open-url` callback.

Closes: https://github.com/lightninglabs/lightning-app/issues/665