### PR TITLE
Display blocks height in notification bar while syncing

### DIFF
--- a/src/action/info.js
+++ b/src/action/info.js
@@ -32,7 +32,10 @@ class InfoAction {
         this.startingSyncTimestamp = response.best_header_timestamp || 0;
       }
       if (!response.synced_to_chain) {
-        this._notification.display({ msg: 'Syncing to chain', wait: true });
+        this._notification.display({
+          msg: `Syncing to chain (block: ${response.block_height})`,
+          wait: true,
+        });
         log.info(`Syncing to chain ... block height: ${response.block_height}`);
         this._store.percentSynced = this.calcPercentSynced(response);
       }

--- a/test/unit/action/info.spec.js
+++ b/test/unit/action/info.spec.js
@@ -42,6 +42,28 @@ describe('Action Info Unit Tests', () => {
       expect(store.blockHeight, 'to equal', 'some-height');
     });
 
+    it('should show notification if syncing', async () => {
+      grpc.sendCommand.withArgs('getInfo').resolves({
+        synced_to_chain: false,
+        block_height: 1234,
+      });
+      await info.getInfo();
+      expect(notification.display, 'was called once');
+      expect(notification.display, 'was called with', {
+        msg: 'Syncing to chain (block: 1234)',
+        wait: true,
+      });
+    });
+
+    it('should not show notification if synced', async () => {
+      grpc.sendCommand.withArgs('getInfo').resolves({
+        synced_to_chain: true,
+        block_height: 1234,
+      });
+      await info.getInfo();
+      expect(notification.display, 'was not called');
+    });
+
     it('should return true if chain is synced', async () => {
       grpc.sendCommand.withArgs('getInfo').resolves({
         synced_to_chain: true,


### PR DESCRIPTION
Closes: https://github.com/lightninglabs/lightning-app/issues/670

![syncing](https://user-images.githubusercontent.com/1056569/45613388-d0f9c980-ba6e-11e8-8688-e03e239d923b.gif)