### PR TITLE
Make list headers sticky

### DIFF
--- a/src/component/list.js
+++ b/src/component/list.js
@@ -50,6 +50,7 @@ export class List extends Component {
         ref={component => (this.list = component)}
         dataSource={this.dataSource}
         renderHeader={this.props.renderHeader}
+        stickyHeaderIndices={this.props.stickyHeaderIndices}
         renderRow={this.props.renderItem}
         enableEmptySections={true}
       />
@@ -61,6 +62,7 @@ List.propTypes = {
   data: PropTypes.array.isRequired,
   renderHeader: PropTypes.func,
   renderItem: PropTypes.func.isRequired,
+  stickyHeaderIndices: PropTypes.array,
 };
 
 //

--- a/src/component/list.js
+++ b/src/component/list.js
@@ -50,7 +50,7 @@ export class List extends Component {
         ref={component => (this.list = component)}
         dataSource={this.dataSource}
         renderHeader={this.props.renderHeader}
-        stickyHeaderIndices={this.props.stickyHeaderIndices}
+        stickyHeaderIndices={[0]}
         renderRow={this.props.renderItem}
         enableEmptySections={true}
       />
@@ -62,7 +62,6 @@ List.propTypes = {
   data: PropTypes.array.isRequired,
   renderHeader: PropTypes.func,
   renderItem: PropTypes.func.isRequired,
-  stickyHeaderIndices: PropTypes.array,
 };
 
 //

--- a/src/view/channel.js
+++ b/src/view/channel.js
@@ -107,7 +107,6 @@ const ChannelList = ({ store, channel }) => {
       />
       <ListContent>
         <List
-          stickyHeaderIndices={[0]}
           data={channels}
           renderHeader={ChannelListHeader}
           renderItem={item => (

--- a/src/view/channel.js
+++ b/src/view/channel.js
@@ -107,8 +107,9 @@ const ChannelList = ({ store, channel }) => {
       />
       <ListContent>
         <List
+          stickyHeaderIndices={[0]}
           data={channels}
-          renderHeader={() => <ChannelListHeader />}
+          renderHeader={ChannelListHeader}
           renderItem={item => (
             <ChannelListItem
               ch={item}
@@ -259,10 +260,13 @@ const hStyles = StyleSheet.create({
     color: color.greyListHeader,
     fontSize: font.sizeXS,
   },
+  header: {
+    backgroundColor: color.blackDark,
+  },
 });
 
 const ChannelListHeader = () => (
-  <ListHeader>
+  <ListHeader style={hStyles.header}>
     <Text style={[iStyles.m, hStyles.txt]}>STATUS</Text>
     <Text style={[iStyles.m, hStyles.txt]}>CAPACITY</Text>
     <Text style={[iStyles.l, hStyles.txt]}>FUNDING TRANSACTION ID</Text>

--- a/src/view/notification.js
+++ b/src/view/notification.js
@@ -28,7 +28,6 @@ const NotificationView = ({ store, nav }) => {
           data={notifications}
           renderHeader={NotificationListHeader}
           renderItem={item => <NotificationListItem item={item} />}
-          stickyHeaderIndices={[0]}
         />
       </ListContent>
     </Background>

--- a/src/view/notification.js
+++ b/src/view/notification.js
@@ -26,8 +26,9 @@ const NotificationView = ({ store, nav }) => {
       <ListContent>
         <List
           data={notifications}
-          renderHeader={() => <NotificationListHeader />}
+          renderHeader={NotificationListHeader}
           renderItem={item => <NotificationListItem item={item} />}
+          stickyHeaderIndices={[0]}
         />
       </ListContent>
     </Background>
@@ -96,10 +97,13 @@ const hStyles = StyleSheet.create({
     color: color.greyListHeader,
     fontSize: font.sizeXS,
   },
+  header: {
+    backgroundColor: color.blackDark,
+  },
 });
 
 const NotificationListHeader = () => (
-  <ListHeader>
+  <ListHeader style={hStyles.header}>
     <Text style={[iStyles.s, hStyles.txt]}>TYPE</Text>
     <Text style={[iStyles.m, hStyles.txt]}>TIME</Text>
     <Text style={[iStyles.l, hStyles.txt]}>DESCRIPTION</Text>

--- a/src/view/transaction.js
+++ b/src/view/transaction.js
@@ -28,13 +28,14 @@ const TransactionView = ({ store, nav, transaction }) => {
       <ListContent>
         <List
           data={transactions}
-          renderHeader={() => <TransactionListHeader />}
+          renderHeader={TransactionListHeader}
           renderItem={item => (
             <TransactionListItem
               tx={item}
               onSelect={() => transaction.select({ item })}
             />
           )}
+          stickyHeaderIndices={[0]}
         />
       </ListContent>
     </Background>
@@ -123,10 +124,13 @@ const hStyles = StyleSheet.create({
     color: color.greyListHeader,
     fontSize: font.sizeXS,
   },
+  header: {
+    backgroundColor: color.blackDark,
+  },
 });
 
 const TransactionListHeader = () => (
-  <ListHeader style={iStyles.item}>
+  <ListHeader style={[iStyles.item, hStyles.header]}>
     <View style={iStyles.i} />
     <Text style={[iStyles.m, hStyles.txt]}>STATUS</Text>
     <Text style={[iStyles.m, hStyles.txt]}>DATE</Text>

--- a/src/view/transaction.js
+++ b/src/view/transaction.js
@@ -35,7 +35,6 @@ const TransactionView = ({ store, nav, transaction }) => {
               onSelect={() => transaction.select({ item })}
             />
           )}
-          stickyHeaderIndices={[0]}
         />
       </ListContent>
     </Background>

--- a/stories/component/list-story.js
+++ b/stories/component/list-story.js
@@ -16,7 +16,7 @@ storiesOf('List', module).add('List Content', () => (
     <List
       data={[...Array(1000)].map((x, i) => ({ id: String(i), data: 'foo' }))}
       renderHeader={() => (
-        <ListHeader>
+        <ListHeader style={{ backgroundColor: color.white }}>
           <Text style={{ flex: 1, color: color.greyText }}>ID</Text>
           <Text style={{ flex: 1, color: color.greyText }}>Data</Text>
         </ListHeader>


### PR DESCRIPTION
In this PR we:
* make `transactions`, `channels` and `notifications` list headers sticky
* upgrade `react-native-web` and its dependencies (`react-art`, `react-dom`, `react-dom`)

The upgrade for `react-native-web` was required because previously `stickyHeaderIndices` for `ListView` was buggy. It's worth noting that the new version also supports [FlatList](https://facebook.github.io/react-native/docs/flatlist) and [SectionList](https://facebook.github.io/react-native/docs/sectionlist) which have lots of improvements over the `ListView`.

During the upgrade process, I verified that all the screens and components didn't visually change/break. The only change needed was for the `Seed` view because `flexGrow` property used in `MainContent` component now works according to the spec - it's assigning `flexBasis` to `auto`. I've included the necessary fix for `Seed` view.

In the future we could add visual regression tests to the storybook stories to make sure the views don't change when upgrading libraries etc.

Channels:
![channels](https://user-images.githubusercontent.com/1056569/45879141-09214500-bdac-11e8-8289-d18739f992ee.gif)

Transactions:
![transactions](https://user-images.githubusercontent.com/1056569/45879131-04f52780-bdac-11e8-8b49-74a2a9f4496d.gif)

Notifications:
![notifications](https://user-images.githubusercontent.com/1056569/45879149-12aaad00-bdac-11e8-82a2-48e5cea473be.gif)

Closes: https://github.com/lightninglabs/lightning-app/issues/611