### PR TITLE
Rename `Pending Deposit` to `Chain Deposit` on home screen

### DIFF
--- a/src/view/home.js
+++ b/src/view/home.js
@@ -111,7 +111,7 @@ const BalanceDisplay = ({
         <BalanceLabelNumeral>{channelBalanceLabel}</BalanceLabelNumeral>
         <BalanceLabelUnit>{unitLabel}</BalanceLabelUnit>
       </BalanceLabel>
-      <H4Text style={balanceStyles.smallLabel}>Pending Deposit</H4Text>
+      <H4Text style={balanceStyles.smallLabel}>Chain Deposit</H4Text>
       <SmallBalanceLabel unit={unitLabel}>{depositLabel}</SmallBalanceLabel>
     </Button>
   </View>


### PR DESCRIPTION
Test wording `Chain Deposit` on home screen as suggested by @Roasbeef. Let's see if this reduces confusion by users as the `Pending` seems to suggest something should happen even after autopilot has completed opening channels.

Closes https://github.com/lightninglabs/lightning-app/issues/636