### PR TITLE
Force close inactive and non open channels

### DIFF
--- a/src/action/channel.js
+++ b/src/action/channel.js
@@ -261,9 +261,12 @@ class ChannelAction {
    */
   async closeSelectedChannel() {
     try {
-      const { selectedChannel } = this._store;
+      const { selectedChannel: selected } = this._store;
       this._nav.goChannels();
-      await this.closeChannel({ channelPoint: selectedChannel.channelPoint });
+      await this.closeChannel({
+        channelPoint: selected.channelPoint,
+        force: selected.status !== 'open' || !selected.active,
+      });
     } catch (err) {
       this._notification.display({ msg: 'Closing channel failed!', err });
     }

--- a/test/unit/action/channel.spec.js
+++ b/test/unit/action/channel.spec.js
@@ -262,6 +262,7 @@ describe('Action Channels Unit Tests', () => {
       store.selectedChannel = {
         channelPoint: 'some-channel-point',
         status: 'open',
+        active: true,
       };
       sandbox.stub(channel, 'closeChannel');
     });
@@ -271,6 +272,27 @@ describe('Action Channels Unit Tests', () => {
       expect(nav.goChannels, 'was called once');
       expect(channel.closeChannel, 'was called with', {
         channelPoint: 'some-channel-point',
+        force: false,
+      });
+    });
+
+    it('should force close inactive open channel', async () => {
+      store.selectedChannel.active = false;
+      await channel.closeSelectedChannel();
+      expect(nav.goChannels, 'was called once');
+      expect(channel.closeChannel, 'was called with', {
+        channelPoint: 'some-channel-point',
+        force: true,
+      });
+    });
+
+    it('should force close pending-open channel', async () => {
+      store.selectedChannel.status = 'pending-open';
+      await channel.closeSelectedChannel();
+      expect(nav.goChannels, 'was called once');
+      expect(channel.closeChannel, 'was called with', {
+        channelPoint: 'some-channel-point',
+        force: true,
       });
     });
 


### PR DESCRIPTION
This PR just enables force close for non open/active channels without any extra copy. We can add design/copy changes after a design iteration. But at least this fix will allow folks to close their channels for now.

Closes #481 