### PR TITLE
Don't show notification count after navigating to view.

### DIFF
--- a/src/action/nav-mobile.js
+++ b/src/action/nav-mobile.js
@@ -142,6 +142,7 @@ class NavAction {
   }
 
   goNotifications() {
+    this._store.unseenNtfnCount = 0;
     this._navigate('Notifications');
   }
 

--- a/src/action/nav.js
+++ b/src/action/nav.js
@@ -143,6 +143,7 @@ class NavAction {
   }
 
   goNotifications() {
+    this._store.unseenNtfnCount = 0;
     this._store.route = 'Notifications';
   }
 

--- a/src/action/notification.js
+++ b/src/action/notification.js
@@ -40,6 +40,7 @@ class NotificationAction {
       handlerLbl: handlerLbl || (err ? 'Show error logs' : null),
       display: true,
     });
+    if (!wait) this._store.unseenNtfnCount += 1;
     clearTimeout(this.tdisplay);
     this.tdisplay = setTimeout(() => this.close(), NOTIFICATION_DELAY);
   }

--- a/src/computed/notification.js
+++ b/src/computed/notification.js
@@ -34,7 +34,7 @@ const ComputedNotification = store => {
       return all;
     },
     get notificationCountLabel() {
-      return formatNumber(store.computedNotifications.length);
+      return formatNumber(store.unseenNtfnCount);
     },
   });
 };

--- a/src/store.js
+++ b/src/store.js
@@ -80,6 +80,7 @@ export class Store {
       paymentRequest: null,
       seedMnemonic: [],
       notifications: [],
+      unseenNtfnCount: 0,
       logs: '',
 
       // Persistent data

--- a/test/unit/action/nav.spec.js
+++ b/test/unit/action/nav.spec.js
@@ -217,9 +217,11 @@ describe('Action Nav Unit Tests', () => {
   });
 
   describe('goNotifications()', () => {
-    it('should set correct route', () => {
+    it('should set correct route and zero unseen ntfns', () => {
+      store.unseenNtfnCount = 10;
       nav.goNotifications();
       expect(store.route, 'to equal', 'Notifications');
+      expect(store.unseenNtfnCount, 'to be', 0);
     });
   });
 

--- a/test/unit/action/notification.spec.js
+++ b/test/unit/action/notification.spec.js
@@ -36,6 +36,7 @@ describe('Action Notification Unit Tests', () => {
       expect(log.info, 'was not called');
       await nap(10);
       expect(store.notifications[0].display, 'to be', false);
+      expect(store.unseenNtfnCount, 'to equal', 1);
     });
 
     it('create warning notification when type is set', () => {

--- a/test/unit/computed/notification.spec.js
+++ b/test/unit/computed/notification.spec.js
@@ -38,6 +38,7 @@ describe('Computed Notification Unit Tests', () => {
         display: true,
         waiting: true,
       });
+      store.unseenNtfnCount = 2;
       ComputedNotification(store);
       expect(store.lastNotification.type, 'to equal', 'info');
       expect(store.displayNotification, 'to equal', true);


### PR DESCRIPTION
Closes #625, #957.

This commit fixes the issue that users expect the notification count label to go away after they've navigated to the page (however, the notification count will re-appear if new notifications come in). 

This issue was brought up by multiple users during the alpha launch.