### PR TITLE
Fix integration test flakes.

### DIFF
--- a/test/integration/action/action-integration.spec.js
+++ b/test/integration/action/action-integration.spec.js
@@ -1,4 +1,4 @@
-import { rmdir, isPortOpen } from './test-util';
+import { rmdir, isPortOpen, killProcess } from './test-util';
 import { Store } from '../../../src/store';
 import IpcAction from '../../../src/action/ipc';
 import GrpcAction from '../../../src/action/grpc';
@@ -280,7 +280,7 @@ describe('Action Integration Tests', function() {
     });
 
     it('should fund wallet for node1', async () => {
-      btcdProcess.kill('SIGINT');
+      await killProcess(btcdProcess.pid);
       btcdArgs.miningAddress = store1.walletAddress;
       btcdProcess = await startBtcdProcess(btcdArgs);
       await nap(NAP_TIME);

--- a/test/integration/action/test-util.js
+++ b/test/integration/action/test-util.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import net from 'net';
+import { nap } from '../../../src/helper';
 
 export const rmdir = path => {
   if (fs.existsSync(path)) {
@@ -23,4 +24,16 @@ export const isPortOpen = async port => {
     client.on('connect', () => client.destroy());
     client.connect(port, 'localhost');
   });
+};
+
+export const killProcess = async pid => {
+  let terminated = false;
+  while (!terminated) {
+    try {
+      process.kill(pid);
+      await nap(500);
+    } catch (e) {
+      terminated = true;
+    }
+  }
 };


### PR DESCRIPTION
Closes #761. 

There is [one odd flake](https://travis-ci.org/lightninglabs/lightning-app/jobs/449677596) that has a slightly different failure, but the other 17 or so had the same failure. 

I've been experiencing this flake locally for a while now, and I'm not sure what about `reset-password` caused it to suddenly surface in production. Regardless, this change fixed it for me locally so I think it should fix it on travis as well.