### PR TITLE
Mainnet full node opt in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-    - LND_TAG=d2186cc9da29853091175189268b073f49586cf0
+    - LND_TAG=a6cf6f4237ef53b1f0c51c2fcfb9c1ce73cf9e06
     - BTCD_TAG=ed77733ec07dfc8a513741138419b8d9d3de9d2d
     - GO_TAG=1.11.4
     - GOROOT=$HOME/go

--- a/README.md
+++ b/README.md
@@ -77,25 +77,25 @@ To run the packaged version of the app e.g. for macOS run:
 ### Starting the Packaged App (full node)
 
 #### btcd
-Start btcd in a seperate terminal session and wait until it's fully synced (can take over a day)
+Start btcd in a seperate terminal session and wait until it's fully synced (can take over a day). Remove the `--testnet` flag for mainnet:
 ```
 btcd --testnet --txindex --rpcuser=kek --rpcpass=kek
 ```
 
-To run the packaged version of the app e.g. for macOS run:
+To run the packaged version of the app e.g. for macOS run (set `--bitcoin.mainnet` for mainnet):
 ```
-./dist/mac/Lightning.app/Contents/MacOS/Lightning --btcd.rpcuser=kek --btcd.rpcpass=kek
+./dist/mac/Lightning.app/Contents/MacOS/Lightning --bitcoin.testnet --btcd.rpcuser=kek --btcd.rpcpass=kek
 ```
 
 #### bitcoind
-Start bitcoind in a seperate terminal session and wait until it's fully synced (can take over a day)
+Start bitcoind in a seperate terminal session and wait until it's fully synced (can take over a day). Remove the `-testnet` flag for mainnet:
 ```
 bitcoind -testnet -txindex=1 -rpcuser=kek -rpcpassword=kek -rpcbind=localhost -zmqpubrawblock=tcp://127.0.0.1:28332 -zmqpubrawtx=tcp://127.0.0.1:28333
 ```
 
-To run the packaged version of the app e.g. for macOS run:
+To run the packaged version of the app e.g. for macOS run (set `--bitcoin.mainnet` for mainnet):
 ```
-./dist/mac/Lightning.app/Contents/MacOS/Lightning --bitcoin.node=bitcoind --bitcoind.rpcuser=kek --bitcoind.rpcpass=kek --bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332 --bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
+./dist/mac/Lightning.app/Contents/MacOS/Lightning --bitcoin.testnet --bitcoin.node=bitcoind --bitcoind.rpcuser=kek --bitcoind.rpcpass=kek --bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332 --bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
 ```
 
 ### Lnd data and logs

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ To run the packaged version of the app e.g. for macOS run:
 ./dist/mac/Lightning.app/Contents/MacOS/Lightning
 ```
 
+The app is configured for testnet by default but you can opt-in to mainnet if you have a btcd node running. Be aware that this is currently still experimental:
+```
+./dist/mac/Lightning.app/Contents/MacOS/Lightning --bitcoin.mainnet --bitcoin.node=neutrino --neutrino.connect=127.0.0.1:8333
+```
+
 ### Starting the Packaged App (full node)
 
 #### btcd

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To run the packaged version of the app e.g. for macOS run:
 ### Starting the Packaged App (full node)
 
 #### btcd
-Start btcd in a seperate terminal session and wait until it's fully synced (can take over a day). Remove the `--testnet` flag for mainnet:
+Start btcd in a separate terminal session and wait until it's fully synced (can take over a day). Remove the `--testnet` flag for mainnet:
 ```
 btcd --testnet --txindex --rpcuser=kek --rpcpass=kek
 ```
@@ -88,7 +88,7 @@ To run the packaged version of the app e.g. for macOS run (set `--bitcoin.mainne
 ```
 
 #### bitcoind
-Start bitcoind in a seperate terminal session and wait until it's fully synced (can take over a day). Remove the `-testnet` flag for mainnet:
+Start bitcoind in a separate terminal session and wait until it's fully synced (can take over a day). Remove the `-testnet` flag for mainnet:
 ```
 bitcoind -testnet -txindex=1 -rpcuser=kek -rpcpassword=kek -rpcbind=localhost -zmqpubrawblock=tcp://127.0.0.1:28332 -zmqpubrawtx=tcp://127.0.0.1:28333
 ```

--- a/assets/rpc.proto
+++ b/assets/rpc.proto
@@ -3,6 +3,9 @@ syntax = "proto3";
 // import "google/api/annotations.proto";
 
 package lnrpc;
+
+option go_package = "github.com/lightningnetwork/lnd/lnrpc";
+
 /**
  * Comments in this file will be directly parsed into the API
  * Documentation as descriptions of the associated method, message, or field.
@@ -231,6 +234,16 @@ service Lightning {
         };
     }
 
+    /** lncli: `listunspent`
+    ListUnspent returns a list of all utxos spendable by the wallet with a
+	number of confirmations between the specified minimum and maximum.
+    */
+    rpc ListUnspent (ListUnspentRequest) returns (ListUnspentResponse) {
+        option (google.api.http) = {
+            get: "/v1/utxos"
+        };
+    }
+
     /**
     SubscribeTransactions creates a uni-directional stream from the server to
     the client in which any newly discovered transactions relevant to the
@@ -260,7 +273,12 @@ service Lightning {
     signature string is `zbase32` encoded and pubkey recoverable, meaning that
     only the message digest and signature are needed for verification.
     */
-    rpc SignMessage (SignMessageRequest) returns (SignMessageResponse);
+    rpc SignMessage (SignMessageRequest) returns (SignMessageResponse) {
+        option (google.api.http) = {
+            post: "/v1/signmessage"
+            body: "*"
+        };
+    }
 
     /** lncli: `verifymessage`
     VerifyMessage verifies a signature over a msg. The signature must be
@@ -268,7 +286,12 @@ service Lightning {
     channel database. In addition to returning the validity of the signature,
     VerifyMessage also returns the recovered pubkey from the signature.
     */
-    rpc VerifyMessage (VerifyMessageRequest) returns (VerifyMessageResponse);
+    rpc VerifyMessage (VerifyMessageRequest) returns (VerifyMessageResponse) {
+        option (google.api.http) = {
+            post: "/v1/verifymessage"
+            body: "*"
+        };
+    }
 
     /** lncli: `connect`
     ConnectPeer attempts to establish a connection to a remote peer. This is at
@@ -335,6 +358,14 @@ service Lightning {
             get: "/v1/channels"
         };
     }
+
+    /** lncli: `subscribechannelevents`
+    SubscribeChannelEvents creates a uni-directional stream from the server to
+    the client in which any updates relevant to the state of the channels are
+    sent over. Events include new active channels, inactive channels, and closed
+    channels.
+    */
+    rpc SubscribeChannelEvents (ChannelEventSubscription) returns (stream ChannelEventUpdate);
 
     /** lncli: `closedchannels`
     ClosedChannels returns a description of all the closed channels that
@@ -455,10 +486,8 @@ service Lightning {
     paginated responses, allowing users to query for specific invoices through
     their add_index. This can be done by using either the first_index_offset or
     last_index_offset fields included in the response as the index_offset of the
-    next request. The reversed flag is set by default in order to paginate
-    backwards. If you wish to paginate forwards, you must explicitly set the
-    flag to false. If none of the parameters are specified, then the last 100
-    invoices will be returned.
+    next request. By default, the first 100 invoices created will be returned.
+    Backwards pagination is also supported through the Reversed flag.
     */
     rpc ListInvoices (ListInvoiceRequest) returns (ListInvoiceResponse) {
         option (google.api.http) = {
@@ -647,6 +676,26 @@ service Lightning {
     };
 }
 
+message Utxo {
+    /// The type of address
+    AddressType type = 1 [json_name = "address_type"];
+
+    /// The address
+    string address = 2 [json_name = "address"];
+
+    /// The value of the unspent coin in satoshis
+    int64 amount_sat = 3 [json_name = "amount_sat"];
+
+    /// The pkscript in hex
+    string pk_script = 4 [json_name = "pk_script"];
+
+    /// The outpoint in format txid:n
+    OutPoint outpoint = 5 [json_name = "outpoint"];
+
+    /// The number of confirmations for the Utxo
+    int64 confirmations = 6 [json_name = "confirmations"];
+}
+
 message Transaction {
     /// The transaction hash
     string tx_hash = 1 [ json_name = "tx_hash" ];
@@ -725,11 +774,18 @@ message SendRequest {
     send the payment.
     */
     FeeLimit fee_limit = 8;
+
+    /**
+    The channel id of the channel that must be taken to the first hop. If zero,
+    any channel may be used.
+    */
+    uint64 outgoing_chan_id = 9;
 }
 message SendResponse {
     string payment_error = 1 [json_name = "payment_error"];
     bytes payment_preimage = 2 [json_name = "payment_preimage"];
     Route payment_route = 3 [json_name = "payment_route"];
+    bytes payment_hash = 4 [json_name = "payment_hash"];
 }
 
 message SendToRouteRequest {
@@ -739,8 +795,16 @@ message SendToRouteRequest {
     /// An optional hex-encoded payment hash to be used for the HTLC.
     string payment_hash_string = 2;
 
-    /// The set of routes that should be used to attempt to complete the payment.
-    repeated Route routes = 3;
+    /**
+    Deprecated. The set of routes that should be used to attempt to complete the
+    payment. The possibility to pass in multiple routes is deprecated and
+    instead the single route field below should be used in combination with the
+    streaming variant of SendToRoute.
+    */
+    repeated Route routes = 3 [deprecated = true];
+
+    /// Route that should be used to attempt to complete the payment.
+    Route route = 4;
 }
 
 message ChannelPoint {
@@ -753,6 +817,17 @@ message ChannelPoint {
     }
 
     /// The index of the output of the funding transaction
+    uint32 output_index = 3 [json_name = "output_index"];
+}
+
+message OutPoint {
+    /// Raw bytes representing the transaction id.
+    bytes txid_bytes = 1 [json_name = "txid_bytes"];
+
+    /// Reversed, hex-encoded string representing the transaction id.
+    string txid_str = 2 [json_name = "txid_str"];
+
+    /// The index of the output on the transaction.
     uint32 output_index = 3 [json_name = "output_index"];
 }
 
@@ -791,10 +866,29 @@ message SendCoinsRequest {
 
     /// A manual fee rate set in sat/byte that should be used when crafting the transaction.
     int64 sat_per_byte = 5;
+
+    /**
+    If set, then the amount field will be ignored, and lnd will attempt to
+    send all the coins under control of the internal wallet to the specified
+    address.
+    */
+    bool send_all = 6;
 }
 message SendCoinsResponse {
     /// The transaction ID of the transaction
     string txid = 1 [json_name = "txid"];
+}
+
+message ListUnspentRequest {
+    /// The minimum number of confirmations to be included.
+    int32 min_confs = 1;
+
+    /// The maximum number of confirmations to be included.
+    int32 max_confs = 2;
+}
+message ListUnspentResponse {
+    /// A list of utxos
+    repeated Utxo utxos = 1 [json_name = "utxos"];
 }
 
 /**
@@ -803,12 +897,12 @@ message SendCoinsResponse {
 - `p2wkh`: Pay to witness key hash (`WITNESS_PUBKEY_HASH` = 0)
 - `np2wkh`: Pay to nested witness key hash (`NESTED_PUBKEY_HASH` = 1)
 */
-message NewAddressRequest {
-    enum AddressType {
+enum AddressType {
         WITNESS_PUBKEY_HASH = 0;
         NESTED_PUBKEY_HASH = 1;
-    }
+}
 
+message NewAddressRequest {
     /// The address type
     AddressType type = 1;
 }
@@ -944,8 +1038,11 @@ message Channel {
     */
     uint32 csv_delay = 16 [json_name = "csv_delay"];
 
-    /// Whether this channel is advertised to the network or not
+    /// Whether this channel is advertised to the network or not.
     bool private = 17 [json_name = "private"];
+
+    /// True if we were the ones that created the channel.
+    bool initiator = 18 [json_name = "initiator"];
 }
 
 
@@ -1075,11 +1172,13 @@ message GetInfoResponse {
     /// Whether the wallet's view is synced to the main chain
     bool synced_to_chain = 9 [json_name = "synced_to_chain"];
 
-    /// Whether the current node is connected to testnet
-    bool testnet = 10 [json_name = "testnet"];
+    /**
+    Whether the current node is connected to testnet. This field is
+    deprecated and the network field should be used instead
+    **/
+    bool testnet = 10 [json_name = "testnet", deprecated = true];
 
-    /// A list of active chains the node is connected to
-    repeated string chains = 11 [json_name = "chains"];
+    reserved 11;
 
     /// The URIs of the current node.
     repeated string uris = 12 [json_name = "uris"];
@@ -1092,6 +1191,17 @@ message GetInfoResponse {
 
     /// Number of inactive channels
     uint32 num_inactive_channels = 15 [json_name = "num_inactive_channels"];
+
+    /// A list of active chains the node is connected to
+    repeated Chain chains = 16 [json_name = "chains"];
+}
+
+message Chain {
+    /// The blockchain the node is on (eg bitcoin, litecoin)
+    string chain = 1 [json_name = "chain"];
+
+    /// The network the node is on (eg regtest, testnet, mainnet)
+    string network = 2 [json_name = "network"];
 }
 
 message ConfirmationUpdate {
@@ -1132,7 +1242,6 @@ message CloseChannelRequest {
 message CloseStatusUpdate {
     oneof update {
         PendingUpdate close_pending = 1 [json_name = "close_pending"];
-        ConfirmationUpdate confirmation = 2 [json_name = "confirmation"];
         ChannelCloseUpdate chan_close = 3 [json_name = "chan_close"];
     }
 }
@@ -1179,7 +1288,6 @@ message OpenChannelRequest {
 message OpenStatusUpdate {
     oneof update {
         PendingUpdate chan_pending = 1 [json_name = "chan_pending"];
-        ConfirmationUpdate confirmation = 2 [json_name = "confirmation"];
         ChannelOpenUpdate chan_open = 3 [json_name = "chan_open"];
     }
 }
@@ -1304,6 +1412,27 @@ message PendingChannelsResponse {
 
     /// Channels waiting for closing tx to confirm
     repeated WaitingCloseChannel waiting_close_channels = 5 [ json_name = "waiting_close_channels" ];
+}
+
+message ChannelEventSubscription {
+}
+
+message ChannelEventUpdate {
+    oneof channel {
+        Channel open_channel = 1 [ json_name = "open_channel" ];
+        ChannelCloseSummary closed_channel = 2 [ json_name = "closed_channel" ];
+        ChannelPoint active_channel = 3 [ json_name = "active_channel" ];
+        ChannelPoint inactive_channel = 4 [ json_name = "inactive_channel" ];
+    }
+
+    enum UpdateType {
+         OPEN_CHANNEL = 0;
+         CLOSED_CHANNEL = 1;
+         ACTIVE_CHANNEL = 2;
+         INACTIVE_CHANNEL = 3;
+    }
+
+    UpdateType type = 5 [ json_name = "type" ];
 }
 
 message WalletBalanceRequest {
@@ -1468,6 +1597,7 @@ message RoutingPolicy {
     int64 fee_base_msat = 3 [json_name = "fee_base_msat"];
     int64 fee_rate_milli_msat = 4 [json_name = "fee_rate_milli_msat"];
     bool disabled = 5 [json_name = "disabled"];
+    uint64 max_htlc_msat = 6 [json_name = "max_htlc_msat"];
 }
 
 /**
@@ -1626,8 +1756,10 @@ message Invoice {
     */
     string memo = 1 [json_name = "memo"];
 
-    /// An optional cryptographic receipt of payment
-    bytes receipt = 2 [json_name = "receipt"];
+    /** Deprecated. An optional cryptographic receipt of payment which is not
+    implemented.
+    */
+    bytes receipt = 2 [json_name = "receipt", deprecated = true];
 
     /**
     The hex-encoded preimage (32 byte) which will allow settling an incoming
@@ -1642,7 +1774,7 @@ message Invoice {
     int64 value = 5 [json_name = "value"];
 
     /// Whether this invoice has been fulfilled
-    bool settled = 6 [json_name = "settled"];
+    bool settled = 6 [json_name = "settled", deprecated = true];
 
     /// When this invoice was created
     int64 creation_date = 7 [json_name = "creation_date"];
@@ -1720,7 +1852,19 @@ message Invoice {
     here as well.
     */
     int64 amt_paid_msat = 20 [json_name = "amt_paid_msat"];
+
+    enum InvoiceState {
+        OPEN = 0;
+        SETTLED = 1;
+        CANCELED = 2;
+    }
+
+    /**
+    The state the invoice is in.
+    */
+    InvoiceState state = 21 [json_name = "state"];
 }
+
 message AddInvoiceResponse {
     bytes r_hash = 1 [json_name = "r_hash"];
 
@@ -1953,14 +2097,17 @@ message ForwardingEvent {
     /// The outgoing channel ID that carried the preimage that completed the circuit.
     uint64 chan_id_out = 4 [json_name = "chan_id_out"];
 
-    /// The total amount of the incoming HTLC that created half the circuit.
+    /// The total amount (in satoshis) of the incoming HTLC that created half the circuit.
     uint64 amt_in = 5 [json_name = "amt_in"];
 
-    /// The total amount of the outgoign HTLC that created the second half of the circuit.
+    /// The total amount (in satoshis) of the outgoing HTLC that created the second half of the circuit.
     uint64 amt_out = 6 [json_name = "amt_out"];
 
-    /// The total fee that this payment circuit carried.
+    /// The total fee (in satoshis) that this payment circuit carried.
     uint64 fee = 7 [json_name = "fee"];
+
+    /// The total fee (in milli-satoshis) that this payment circuit carried.
+    uint64 fee_msat = 8 [json_name = "fee_msat"];
 
     // TODO(roasbeef): add settlement latency?
     //  * use FPE on the chan id?

--- a/assets/script/install_lnd.sh
+++ b/assets/script/install_lnd.sh
@@ -18,6 +18,8 @@ mv go $HOME
 git clone https://github.com/lightningnetwork/lnd $GOPATH/src/github.com/lightningnetwork/lnd
 cd $GOPATH/src/github.com/lightningnetwork/lnd
 git checkout $LND_TAG
+# enable mainnet neutrino in lnd
+git fetch https://github.com/halseth/lnd.git mainnet-neutrino && git cherry-pick d1c23009e00298ed50173fb7cd60bdfb2937d50f
 make && make install tags=experimental
 
 # install btcd

--- a/public/electron.js
+++ b/public/electron.js
@@ -9,7 +9,6 @@ const { startLndProcess, startBtcdProcess } = require('./lnd-child-process');
 const grcpClient = require('./grpc-client');
 const {
   PREFIX_NAME,
-  NETWORK,
   LND_PORT,
   LND_PEER_PORT,
   LND_REST_PORT,
@@ -126,7 +125,11 @@ function createWindow() {
     ipcMain,
     lndSettingsDir,
     lndPort: LND_PORT,
-    network: isDev ? 'simnet' : NETWORK,
+    network: isDev
+      ? 'simnet'
+      : lndArgs.includes('--bitcoin.mainnet')
+        ? 'mainnet'
+        : 'testnet',
   });
 }
 

--- a/public/lnd-child-process.js
+++ b/public/lnd-child-process.js
@@ -76,7 +76,6 @@ module.exports.startLndProcess = async function({
     ]);
   } else {
     args = args.concat([
-      '--bitcoin.testnet',
       '--autopilot.active',
       '--autopilot.private',
       '--autopilot.minconfs=0',
@@ -86,6 +85,7 @@ module.exports.startLndProcess = async function({
   // set default production settings if no custom flags
   if (!isDev && !lndArgs.length) {
     args = args.concat([
+      '--bitcoin.testnet',
       '--bitcoin.node=neutrino',
       '--neutrino.connect=btcd0.lightning.engineering',
       '--neutrino.connect=127.0.0.1:18333',

--- a/src/config.js
+++ b/src/config.js
@@ -14,7 +14,6 @@ module.exports.LND_PEER_PORT = 10016;
 module.exports.LND_REST_PORT = 8086;
 module.exports.LND_PROFILING_PORT = 9096;
 
-module.exports.NETWORK = 'testnet';
 module.exports.BTCD_MINING_ADDRESS = 'rfu4i1Mo2NF7TQsN9bMVLFSojSzcyQCEH5';
 
 const prefixName = 'lightning';


### PR DESCRIPTION
This change should allow users to opt into mainnet when running a full node, sidestepping the neutrino dependency in the short term. Obviously this required about 200 GB of storage. But it will allow us to start testing the app more thoroughly before our neutrino launch.