### PR TITLE
Display blocks to maturity on channel detail view.

### DIFF
--- a/src/action/channel.js
+++ b/src/action/channel.js
@@ -3,7 +3,7 @@
  * call the corresponding GRPC apis for channel management.
  */
 
-import { toSatoshis, poll, formatTimeTilMaturity } from '../helper';
+import { toSatoshis, poll, getTimeTilAvailable } from '../helper';
 import * as log from './log';
 
 class ChannelAction {
@@ -160,7 +160,7 @@ class ChannelAction {
         limboBalance: pfcc.limboBalance,
         maturityHeight: pfcc.maturityHeight,
         blocksTilMaturity: pfcc.blocksTilMaturity,
-        timeTilAvailable: formatTimeTilMaturity(pfcc.blocksTilMaturity),
+        timeTilAvailable: getTimeTilAvailable(pfcc.blocksTilMaturity),
         status: 'pending-force-closing',
       }));
       const wccs = response.waitingCloseChannels.map(wcc => ({

--- a/src/action/channel.js
+++ b/src/action/channel.js
@@ -3,7 +3,7 @@
  * call the corresponding GRPC apis for channel management.
  */
 
-import { toSatoshis, poll } from '../helper';
+import { toSatoshis, poll, formatTimeTilMaturity } from '../helper';
 import * as log from './log';
 
 class ChannelAction {
@@ -160,7 +160,7 @@ class ChannelAction {
         limboBalance: pfcc.limboBalance,
         maturityHeight: pfcc.maturityHeight,
         blocksTilMaturity: pfcc.blocksTilMaturity,
-        timeTilAvailable: this._formatTimeTilMaturity(pfcc.blocksTilMaturity),
+        timeTilAvailable: formatTimeTilMaturity(pfcc.blocksTilMaturity),
         status: 'pending-force-closing',
       }));
       const wccs = response.waitingCloseChannels.map(wcc => ({
@@ -346,12 +346,6 @@ class ChannelAction {
     const pc = this._store.pendingChannels;
     const channel = pc.find(c => c.channelPoint === channelPoint);
     if (channel) pc.splice(pc.indexOf(channel));
-  }
-
-  _formatTimeTilMaturity(numBlocks) {
-    const days = Math.floor(numBlocks / (24 * 6));
-    const hours = Math.floor((numBlocks % (24 * 6)) / 6);
-    return `${days} days and ${hours} hours`;
   }
 }
 

--- a/src/action/channel.js
+++ b/src/action/channel.js
@@ -160,6 +160,7 @@ class ChannelAction {
         limboBalance: pfcc.limboBalance,
         maturityHeight: pfcc.maturityHeight,
         blocksTilMaturity: pfcc.blocksTilMaturity,
+        timeTilAvailable: this._formatTimeTilMaturity(pfcc.blocksTilMaturity),
         status: 'pending-force-closing',
       }));
       const wccs = response.waitingCloseChannels.map(wcc => ({
@@ -345,6 +346,12 @@ class ChannelAction {
     const pc = this._store.pendingChannels;
     const channel = pc.find(c => c.channelPoint === channelPoint);
     if (channel) pc.splice(pc.indexOf(channel));
+  }
+
+  _formatTimeTilMaturity(numBlocks) {
+    const days = Math.floor(numBlocks / (24 * 6));
+    const hours = Math.floor((numBlocks % (24 * 6)) / 6);
+    return `${days} days and ${hours} hours`;
   }
 }
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -321,3 +321,15 @@ export const generateArc = (x, y, radius, startAngle, endAngle) => {
     'Z',
   ].join(' ');
 };
+
+/**
+ * Convert a number of blocks to an amount of time in the format "X days and Y
+ * hours" assuming 10 minutes per block.
+ * @param  {number} numBlocks The number of blocks to convert.
+ * @return {string} The amount of time the blocks is equivalent to.
+ */
+export const formatTimeTilMaturity = numBlocks => {
+  const days = Math.floor(numBlocks / (24 * 6));
+  const hours = Math.floor((numBlocks % (24 * 6)) / 6);
+  return `${days} days and ${hours} hours`;
+};

--- a/src/helper.js
+++ b/src/helper.js
@@ -329,12 +329,11 @@ export const generateArc = (x, y, radius, startAngle, endAngle) => {
  * @return {string} The amount of time the blocks is equivalent to.
  */
 export const getTimeTilAvailable = numBlocks => {
-  let num = Number(numBlocks);
-  if (isNaN(num)) {
+  if (!Number.isInteger(numBlocks)) {
     throw new Error('Invalid input!');
   }
-  const days = Math.floor(num / (24 * 6));
-  const hours = Math.floor((num % (24 * 6)) / 6);
+  const days = Math.floor(numBlocks / (24 * 6));
+  const hours = Math.floor((numBlocks % (24 * 6)) / 6);
   const daysString = days === 1 ? 'day' : 'days';
   const hoursString = hours === 1 ? 'hour' : 'hours';
   return `${days} ${daysString} and ${hours} ${hoursString}`;

--- a/src/helper.js
+++ b/src/helper.js
@@ -329,8 +329,12 @@ export const generateArc = (x, y, radius, startAngle, endAngle) => {
  * @return {string} The amount of time the blocks is equivalent to.
  */
 export const getTimeTilAvailable = numBlocks => {
-  const days = Math.floor(numBlocks / (24 * 6));
-  const hours = Math.floor((numBlocks % (24 * 6)) / 6);
+  let num = Number(numBlocks);
+  if (isNaN(num)) {
+    throw new Error('Invalid input!');
+  }
+  const days = Math.floor(num / (24 * 6));
+  const hours = Math.floor((num % (24 * 6)) / 6);
   const daysString = days === 1 ? 'day' : 'days';
   const hoursString = hours === 1 ? 'hour' : 'hours';
   return `${days} ${daysString} and ${hours} ${hoursString}`;

--- a/src/helper.js
+++ b/src/helper.js
@@ -328,8 +328,10 @@ export const generateArc = (x, y, radius, startAngle, endAngle) => {
  * @param  {number} numBlocks The number of blocks to convert.
  * @return {string} The amount of time the blocks is equivalent to.
  */
-export const formatTimeTilMaturity = numBlocks => {
+export const getTimeTilAvailable = numBlocks => {
   const days = Math.floor(numBlocks / (24 * 6));
   const hours = Math.floor((numBlocks % (24 * 6)) / 6);
-  return `${days} days and ${hours} hours`;
+  const daysString = days === 1 ? 'day' : 'days';
+  const hoursString = hours === 1 ? 'hour' : 'hours';
+  return `${days} ${daysString} and ${hours} ${hoursString}`;
 };

--- a/src/helper.js
+++ b/src/helper.js
@@ -138,6 +138,23 @@ export const toLabel = (amount, settings) => {
 };
 
 /**
+ * Convert a number of blocks to an amount of time in the format "X days and Y
+ * hours" assuming 10 minutes per block.
+ * @param  {number} numBlocks The number of blocks to convert.
+ * @return {string} The amount of time the blocks is equivalent to.
+ */
+export const getTimeTilAvailable = numBlocks => {
+  if (!Number.isInteger(numBlocks)) {
+    throw new Error('Invalid input!');
+  }
+  const days = Math.floor(numBlocks / (24 * 6));
+  const hours = Math.floor((numBlocks % (24 * 6)) / 6);
+  const daysString = days === 1 ? 'day' : 'days';
+  const hoursString = hours === 1 ? 'hour' : 'hours';
+  return `${days} ${daysString} and ${hours} ${hoursString}`;
+};
+
+/**
  * Split '_' separated words and convert to uppercase
  * @param  {string} value     The input string
  * @param  {string} separator The separator to be used
@@ -320,21 +337,4 @@ export const generateArc = (x, y, radius, startAngle, endAngle) => {
     `A ${radius} ${radius} 0 ${largeArcFlag} ${sweepFlag} ${end.x} ${end.y}`,
     'Z',
   ].join(' ');
-};
-
-/**
- * Convert a number of blocks to an amount of time in the format "X days and Y
- * hours" assuming 10 minutes per block.
- * @param  {number} numBlocks The number of blocks to convert.
- * @return {string} The amount of time the blocks is equivalent to.
- */
-export const getTimeTilAvailable = numBlocks => {
-  if (!Number.isInteger(numBlocks)) {
-    throw new Error('Invalid input!');
-  }
-  const days = Math.floor(numBlocks / (24 * 6));
-  const hours = Math.floor((numBlocks % (24 * 6)) / 6);
-  const daysString = days === 1 ? 'day' : 'days';
-  const hoursString = hours === 1 ? 'hour' : 'hours';
-  return `${days} ${daysString} and ${hours} ${hoursString}`;
 };

--- a/src/view/channel-detail.js
+++ b/src/view/channel-detail.js
@@ -42,17 +42,17 @@ const ChannelDetailView = ({ store, nav }) => (
             {store.selectedChannel.closingTxId}
           </DetailField>
         ) : null}
-        {store.selectedChannel.timeTilAvailable ? (
-          <DetailField name="Time Til Available">
-            {store.selectedChannel.timeTilAvailable}
-          </DetailField>
-        ) : null}
         <DetailField name="Remote Node Public Key">
           {store.selectedChannel.remotePubkey}
         </DetailField>
         <DetailField name="Status">
           {store.selectedChannel.statusLabel}
         </DetailField>
+        {store.selectedChannel.timeTilAvailable ? (
+          <DetailField name="Time Til Available">
+            {store.selectedChannel.timeTilAvailable}
+          </DetailField>
+        ) : null}
         <DetailField name="Capacity">
           {store.selectedChannel.capacityLabel} {store.unitLabel}
         </DetailField>

--- a/src/view/channel-detail.js
+++ b/src/view/channel-detail.js
@@ -42,6 +42,11 @@ const ChannelDetailView = ({ store, nav }) => (
             {store.selectedChannel.closingTxId}
           </DetailField>
         ) : null}
+        {store.selectedChannel.blocksTilMaturity ? (
+          <DetailField name="Blocks Until Maturity">
+            {store.selectedChannel.blocksTilMaturity}
+          </DetailField>
+        ) : null}
         <DetailField name="Remote Node Public Key">
           {store.selectedChannel.remotePubkey}
         </DetailField>

--- a/src/view/channel-detail.js
+++ b/src/view/channel-detail.js
@@ -43,8 +43,8 @@ const ChannelDetailView = ({ store, nav }) => (
           </DetailField>
         ) : null}
         {store.selectedChannel.blocksTilMaturity ? (
-          <DetailField name="Blocks Until Maturity">
-            {store.selectedChannel.blocksTilMaturity}
+          <DetailField name="Time Til Available">
+            {store.selectedChannel.timeTilAvailable}
           </DetailField>
         ) : null}
         <DetailField name="Remote Node Public Key">

--- a/src/view/channel-detail.js
+++ b/src/view/channel-detail.js
@@ -42,7 +42,7 @@ const ChannelDetailView = ({ store, nav }) => (
             {store.selectedChannel.closingTxId}
           </DetailField>
         ) : null}
-        {store.selectedChannel.blocksTilMaturity ? (
+        {store.selectedChannel.timeTilAvailable ? (
           <DetailField name="Time Til Available">
             {store.selectedChannel.timeTilAvailable}
           </DetailField>

--- a/test/unit/action/channel.spec.js
+++ b/test/unit/action/channel.spec.js
@@ -146,7 +146,12 @@ describe('Action Channels Unit Tests', () => {
       grpc.sendCommand.withArgs('pendingChannels').resolves({
         pendingOpenChannels: [{ channel: { ...pendingChannel } }],
         pendingClosingChannels: [{ channel: { ...pendingChannel } }],
-        pendingForceClosingChannels: [{ channel: { ...pendingChannel } }],
+        pendingForceClosingChannels: [
+          {
+            channel: { ...pendingChannel },
+            blocksTilMaturity: 463,
+          },
+        ],
         waitingCloseChannels: [{ channel: { ...pendingChannel } }],
         totalLimboBalance: 1,
       });
@@ -155,6 +160,9 @@ describe('Action Channels Unit Tests', () => {
       expect(store.pendingChannels[0], 'to satisfy', {
         remotePubkey: 'some-key',
         fundingTxId: 'FFFF',
+      });
+      expect(store.pendingChannels[2], 'to satisfy', {
+        timeTilAvailable: '3 days and 5 hours',
       });
     });
 

--- a/test/unit/helper.spec.js
+++ b/test/unit/helper.spec.js
@@ -818,11 +818,28 @@ describe('Helpers Unit Tests', () => {
     });
   });
 
-  describe('formatTimeTilMaturity()', () => {
+  describe('getTimeTilAvailable()', () => {
     it('should format blocks to human-readable time', () => {
       const numBlocks = 463;
-      const time = helpers.formatTimeTilMaturity(numBlocks);
+      const time = helpers.getTimeTilAvailable(numBlocks);
       expect(time, 'to equal', '3 days and 5 hours');
+    });
+
+    it('should show NaN for undefined', () => {
+      const time = helpers.getTimeTilAvailable(undefined);
+      expect(time, 'to equal', 'NaN days and NaN hours');
+    });
+
+    it('should work for 1 day and 1 hour', () => {
+      const numBlocks = 150;
+      const time = helpers.getTimeTilAvailable(numBlocks);
+      expect(time, 'to equal', '1 day and 1 hour');
+    });
+
+    it('should work for 0', () => {
+      const numBlocks = 0;
+      const time = helpers.getTimeTilAvailable(numBlocks);
+      expect(time, 'to equal', '0 days and 0 hours');
     });
   });
 });

--- a/test/unit/helper.spec.js
+++ b/test/unit/helper.spec.js
@@ -825,9 +825,12 @@ describe('Helpers Unit Tests', () => {
       expect(time, 'to equal', '3 days and 5 hours');
     });
 
-    it('should show NaN for undefined', () => {
-      const time = helpers.getTimeTilAvailable(undefined);
-      expect(time, 'to equal', 'NaN days and NaN hours');
+    it('should error on undefined', () => {
+      expect(
+        helpers.getTimeTilAvailable.bind(undefined),
+        'to throw',
+        /Invalid/
+      );
     });
 
     it('should work for 1 day and 1 hour', () => {

--- a/test/unit/helper.spec.js
+++ b/test/unit/helper.spec.js
@@ -817,4 +817,12 @@ describe('Helpers Unit Tests', () => {
       );
     });
   });
+
+  describe('formatTimeTilMaturity()', () => {
+    it('should format blocks to human-readable time', () => {
+      const numBlocks = 463;
+      const time = helpers.formatTimeTilMaturity(numBlocks);
+      expect(time, 'to equal', '3 days and 5 hours');
+    });
+  });
 });


### PR DESCRIPTION
Closes #525.

"Blocks to maturity" doesn't seem like the best copy. Any ideas for what would be better?