### PR TITLE
Fix lnd safe shutdown.

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -137,7 +137,7 @@ ipcMain.on('lnd-restart-process', async event => {
   lndProcess && lndProcess.kill('SIGINT');
   let restartError;
   try {
-    lndProcess = await startLndProcess({
+    lndProcess = startLndProcess({
       isDev,
       lndSettingsDir,
       lndPort: LND_PORT,
@@ -151,15 +151,15 @@ ipcMain.on('lnd-restart-process', async event => {
   event.sender.send('lnd-restart-error', { restartError });
 });
 
-const startLnd = async () => {
+const startLnd = () => {
   try {
-    btcdProcess = await startBtcdProcess({
+    btcdProcess = startBtcdProcess({
       isDev,
       logger: Logger,
       btcdSettingsDir,
       miningAddress: BTCD_MINING_ADDRESS,
     });
-    lndProcess = await startLndProcess({
+    lndProcess = startLndProcess({
       isDev,
       lndSettingsDir,
       lndPort: LND_PORT,

--- a/test/integration/action/action-integration.spec.js
+++ b/test/integration/action/action-integration.spec.js
@@ -95,8 +95,8 @@ describe('Action Integration Tests', function() {
   let autopilot2;
   let btcdArgs;
 
-  const startLnd = async () => {
-    const lndProcess1Promise = startLndProcess({
+  const startLnd = () => {
+    lndProcess1 = startLndProcess({
       isDev,
       lndSettingsDir: LND_SETTINGS_DIR_1,
       lndPort: LND_PORT_1,
@@ -104,7 +104,7 @@ describe('Action Integration Tests', function() {
       lndRestPort: LND_REST_PORT_1,
       logger,
     });
-    const lndProcess2Promise = startLndProcess({
+    lndProcess2 = startLndProcess({
       isDev,
       lndSettingsDir: LND_SETTINGS_DIR_2,
       lndPort: LND_PORT_2,
@@ -112,9 +112,6 @@ describe('Action Integration Tests', function() {
       lndRestPort: LND_REST_PORT_2,
       logger,
     });
-
-    lndProcess1 = await lndProcess1Promise;
-    lndProcess2 = await lndProcess2Promise;
   };
 
   before(async () => {
@@ -136,12 +133,12 @@ describe('Action Integration Tests', function() {
       btcdSettingsDir: BTCD_SETTINGS_DIR,
       miningAddress: BTCD_MINING_ADDRESS,
     };
-    btcdProcess = await startBtcdProcess(btcdArgs);
+    btcdProcess = startBtcdProcess(btcdArgs);
     await nap(NAP_TIME);
     await retry(() => isPortOpen(BTCD_PORT));
     await mineBlocks({ blocks: 400, logger });
 
-    await startLnd();
+    startLnd();
 
     await grcpClient.init({
       ipcMain: ipcMainStub1,
@@ -239,7 +236,7 @@ describe('Action Integration Tests', function() {
     it('should reset password', async () => {
       lndProcess1.kill('SIGINT');
       lndProcess2.kill('SIGINT');
-      await startLnd();
+      startLnd();
       ipcMainStub1.on('lnd-restart-process', async event => {
         event.sender.send('lnd-restart-error', { restartError: undefined });
       });
@@ -263,7 +260,7 @@ describe('Action Integration Tests', function() {
     it('should unlock wallet with reset password', async () => {
       lndProcess1.kill();
       lndProcess2.kill();
-      await startLnd();
+      startLnd();
 
       store1.walletUnlocked = false;
       await grpc1.initUnlocker();
@@ -292,7 +289,7 @@ describe('Action Integration Tests', function() {
     it('should fund wallet for node1', async () => {
       await killProcess(btcdProcess.pid);
       btcdArgs.miningAddress = store1.walletAddress;
-      btcdProcess = await startBtcdProcess(btcdArgs);
+      btcdProcess = startBtcdProcess(btcdArgs);
       await nap(NAP_TIME);
       await retry(() => isPortOpen(BTCD_PORT));
       await mineAndSync({ blocks: 100 });


### PR DESCRIPTION
lnd needs to be able to shutdown fully, and currently because it's a child process
of the main node process, it is killed when the app is killed and isn't given a
chance to fully tear down. Now, we start lnd as a detached process that can die
at its own pace when the app is closed.

A potential downside is that the lnd logs no longer appear alongside the app logs.
However, the lnd logs are still accessible in the app's data directory.

Depends on #1136. Closes #802.