### PR TITLE
Update lnd version for safe shutdown fix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-    - LND_TAG=4068e78af690f9b4a598de1f3f0b21b5560dd146
+    - LND_TAG=0139300a00eeb3ce0411566840266c993fd70ddc
     - BTCD_TAG=16327141da8ce4b46b5bac57ba01352943465d9e
     - GO_TAG=1.12.1
     - GOROOT=$HOME/go


### PR DESCRIPTION
We need this update for the safe shutdown fix (#1134) to work.