### PR TITLE
MXN amounts; depends on MXN ticker to be included on API response

### DIFF
--- a/src/action/index-mobile.js
+++ b/src/action/index-mobile.js
@@ -150,6 +150,7 @@ store.channelBalanceSatoshis = 598760;
 store.settings.exchangeRate.usd = 0.00016341;
 store.settings.exchangeRate.eur = 0.0001896;
 store.settings.exchangeRate.gbp = 0.00021405;
+store.settings.exchangeRate.mxn = 0.00000566;
 store.invoice.amount = '0.45678';
 store.invoice.note = 'For the love of bitcoin';
 store.invoice.encoded =

--- a/src/computed/setting.js
+++ b/src/computed/setting.js
@@ -32,6 +32,9 @@ const ComputedSetting = store => {
     get gbpFiatLabel() {
       return FIATS['gbp'].displayLong;
     },
+    get mxnFiatLabel() {
+      return FIATS['mxn'].displayLong;
+    },
   });
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,7 @@ module.exports.FIATS = {
   usd: { display: '$', displayLong: 'US Dollar' },
   eur: { display: '€', displayLong: 'Euro' },
   gbp: { display: '£', displayLong: 'British Pound' },
+  mxn: { display: '$', displayLong: 'Mexican Peso' },
 };
 module.exports.DEFAULT_UNIT = 'sat';
 module.exports.DEFAULT_FIAT = 'usd';

--- a/src/view/setting-fiat.js
+++ b/src/view/setting-fiat.js
@@ -39,6 +39,12 @@ const SettingFiatView = ({ store, nav, setting }) => {
           >
             <RadioButton selected={'gbp' === store.settings.fiat} />
           </SettingItem>
+          <SettingItem
+            name={store.mxnFiatLabel}
+            onSelect={() => setting.setFiatCurrency({ fiat: 'mxn' })}
+          >
+            <RadioButton selected={'mxn' === store.settings.fiat} />
+          </SettingItem>
         </SettingList>
       </SettingContent>
     </Background>

--- a/stories/screen-story.js
+++ b/stories/screen-story.js
@@ -300,6 +300,7 @@ store.channelBalanceSatoshis = 598760;
 store.settings.exchangeRate.usd = 0.00016341;
 store.settings.exchangeRate.eur = 0.0001896;
 store.settings.exchangeRate.gbp = 0.00021405;
+store.settings.exchangeRate.mxn = 0.00000566;
 store.invoice.amount = '0.45678';
 store.invoice.note = 'For the love of bitcoin';
 store.invoice.encoded =

--- a/test/unit/action/wallet.spec.js
+++ b/test/unit/action/wallet.spec.js
@@ -628,6 +628,11 @@ describe('Action Wallet Unit Tests', () => {
           "date": "2019-04-04T03:30:05.000Z",
           "rate": 498467,
           "ticker": "USD"
+        },
+        {
+          "date": "2019-04-04T03:30:05.000Z",
+          "rate": 9401718,
+          "ticker": "MXN"
         }
       ]
     }`;

--- a/test/unit/computed/setting.spec.js
+++ b/test/unit/computed/setting.spec.js
@@ -23,6 +23,7 @@ describe('Computed Settings Unit Tests', () => {
       expect(store.usdFiatLabel, 'to be ok');
       expect(store.eurFiatLabel, 'to be ok');
       expect(store.gbpFiatLabel, 'to be ok');
+      expect(store.mxnFiatLabel, 'to be ok');
     });
 
     it('should display satoshis denominated in BTC', () => {


### PR DESCRIPTION
It depends on MXN rates being included on API response; may be we could use Bitso's:
https://api.bitso.com/v3/ticker/?book=btc_mxn

I'll be glad to send a PR to API repo if you point me to where is it.