### PR TITLE
mobile: disable listening on Android+iOS

### DIFF
--- a/mobile/android/app/src/main/assets/lnd.conf
+++ b/mobile/android/app/src/main/assets/lnd.conf
@@ -2,6 +2,7 @@
 debuglevel=info
 no-macaroons=1
 maxbackoff=2s
+nolisten=1
 
 [Routing]
 routing.assumechanvalid=1

--- a/mobile/ios/lightning/lnd.conf
+++ b/mobile/ios/lightning/lnd.conf
@@ -2,6 +2,7 @@
 debuglevel=info
 no-macaroons=1
 maxbackoff=2s
+nolisten=1
 
 [Routing]
 routing.assumechanvalid=1


### PR DESCRIPTION
In this commit, we disable listening on Android and iOS in order to
ensure that we don't conflict with any other LN apps the user may have
that are also attempting to listen on port 9735.

Fixes #1184.