### PR TITLE
fix empty seedMnemonic in initSeed

### DIFF
--- a/src/action/wallet.js
+++ b/src/action/wallet.js
@@ -279,8 +279,8 @@ class WalletAction {
   }
 
   /**
-   * Initialize the seed flow by navigating to the proper next view and
-   * resetting the current seed index.
+   * Check the existing mnemonic seed and Initialize the seed flow by navigating to
+   * the proper next view and resetting the current seed index.
    * @return {undefined}
    */
   async initSeed() {

--- a/src/action/wallet.js
+++ b/src/action/wallet.js
@@ -283,7 +283,10 @@ class WalletAction {
    * resetting the current seed index.
    * @return {undefined}
    */
-  initSeed() {
+  async initSeed() {
+    if (this._store.seedMnemonic.some(value => value === '')) {
+      await this.generateSeed();
+    }
     this._store.wallet.seedIndex = 0;
     this._nav.goSeedIntro ? this._nav.goSeedIntro() : this._nav.goSeed();
   }

--- a/src/view/select-seed.js
+++ b/src/view/select-seed.js
@@ -72,10 +72,10 @@ const SelectSeedView = ({ store, wallet, setting }) => (
       </View>
     </MainContent>
     <GlasButton
-      onPress={() =>
+      onPress={async () =>
         store.settings.restoring
           ? wallet.initRestoreWallet()
-          : wallet.initSeed()
+          : await wallet.initSeed()
       }
     >
       Next


### PR DESCRIPTION
Origin of the bug #1206 & #1174 the seed is cleared if the user select recover an existing wallet then navigate back to home/Main screen and select generate a new wallet, so I suggest to check in `initSeed()` if the seedMnemonic is empty before navigating to generate a new wallet screen!