### PR TITLE
Update readme docs for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,30 +21,33 @@ See the `ToDo (next release)` column on our [project board](https://github.com/l
 
 ### Developing Locally
 
+To build the mobile app locally, see the [README](https://github.com/lightninglabs/lightning-app/blob/master/mobile/README.md) in the `/mobile` directory for instructions.
+
+To build the desktop app locally follow the instructions below:
+
 #### Install lnd
+We will use `lnd` to make GRPC calls from the ReactJS environment
 ```
 git clone https://github.com/lightningnetwork/lnd $GOPATH/src/github.com/lightningnetwork/lnd
 cd $GOPATH/src/github.com/lightningnetwork/lnd
 make && make install tags="experimental autopilotrpc"
 ```
+If you have any issues with this step, make sure to review the [Preliniaries to installing LND](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md#preliminaries)
 
 #### Install btcd
+We will use `btcd` as the backend operating mode
 ```
 git clone https://github.com/btcsuite/btcd $GOPATH/src/github.com/btcsuite/btcd
 cd $GOPATH/src/github.com/btcsuite/btcd
 GO111MODULE=on go install -v . ./cmd/...
 ```
 
-Then start by cloning this git repo and go inside the project folder to run the following commands:
+#### Set up & run
+Cloning this git repo `git clone https://github.com/lightninglabs/lightning-app` and from the project root folder run the following commands:
 ```
 npm install
 
 npm test
-```
-
-To build the UI style guide
-```
-npm run storybook
 ```
 
 To start the app in development mode (simnet):
@@ -53,6 +56,13 @@ npm run electron-dev
 ```
 
 Running in development mode can allow you to run in full node mode instead of the default neutrino mode, and will also allow you to run in simnet node for testing. The app will use it's own lnd `data/lnd` dir and does not share state with other lnd installations on your system. See [setup local cluster](https://github.com/lightninglabs/lightning-app/blob/master/assets/script/setup_local_cluster.md) on how to set up your simnet cluster for development.
+
+#### Review UI style guide
+
+To build the UI style guide
+```
+npm run storybook
+```
 
 ### Building the Packaged App
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -5,44 +5,58 @@ Lightning mobile app
 
 This project was bootstrapped using [Expo CLI as a bare project](https://blog.expo.io/you-can-now-use-expo-apis-in-any-react-native-app-7c3a93041331). You should only need `react-native-cli` for development not `expo-cli`. See the [React Native CLI Getting Started Guide](https://facebook.github.io/react-native/docs/getting-started.html)
 
-## Building lnd
+## Checking build dependencies
 
-### Build dependencies
+Ensure you have all the following dependencies installed for a complete development environment
 
-* node 10 LTS (brew install node@10)
-* react-native-cli (npm install -g react-native-cli)
-* watchman (brew install watchman)
+* node 10 LTS (`brew install node@10`)
+* react-native-cli (`npm install -g react-native-cli`)
+* watchman (`brew install watchman`)
+* go 1.11.x (`brew install go@1.11`)
+* protoc (`brew install protobuf`)
+* [gomobile](https://github.com/golang/go/wiki/Mobile) (`go get -u golang.org/x/mobile/cmd/gomobile`)
+* falafel (`go get -u github.com/halseth/falafel`)
+
+_Required for iOS_
 * Xcode
-* cocoapods 1.7.2 (brew install cocoapods)
-* go 1.11.x (brew install go@1.11)
-* protoc (brew install protobuf)
-* [gomobile](https://github.com/golang/go/wiki/Mobile) (go get -u golang.org/x/mobile/cmd/gomobile)
-* falafel (go get -u github.com/halseth/falafel)
-* [lnd mobile build tools](https://github.com/lightninglabs/lnd/tree/mobile-autopilot-100)
+* cocoapods 1.7.2 (`brew install cocoapods`)
+
+_Required for Android_
 * [Java](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
 * [Android Studio](https://developer.android.com/studio)
 * [Android NDK](https://developer.android.com/ndk/guides)
 
-### Building
+## Building lnd
+
+Before running the app, we will build mobile binaries for `lnd` so GRPC calls can be made during runtime. Check that your version of lnd (v0.8.0+) includes the lnd mobile build tools added in [this PR](https://github.com/lightningnetwork/lnd/pull/3282). Then from the `lnd` project root run:
 
 ```
-cd lnd
 make clean
 gomobile init
-make mobile
 ```
 
-Next copy the lnd mobile binaries to this project
+Build the binaries for each platform
+```
+make ios        // only iOS
+make android    // only Android
+make mobile     // both iOS + Android
+```
 
-1. `lnd/mobile/build/ios/Lndmobile.framework` -> `ios/lightning`
-2. `lnd/mobile/build/android/Lndmobile.aar` -> `android/Lndmobile`
+Next clone this project `git clone https://github.com/lightninglabs/lightning-app` and copy the `lnd` mobile binaries over to their respective directories:
+
+1. `lnd/mobile/build/ios/Lndmobile.framework` -> `lightning-app/mobile/ios/lightning`
+2. `lnd/mobile/build/android/Lndmobile.aar` -> `lightning-app/mobile/android/Lndmobile`
 
 ## Running the app
 
-### Install the dependencies
+### Install dependencies
+
+From the `/lightning-app` project root run
 
 ```
-npm install (first in git `/` and then in `/mobile`)
+npm install
+cd mobile
+npm install
 cd ios
 pod install
 cd ..
@@ -55,7 +69,7 @@ npm run ios
 npm run android
 ```
 
-### Debugging the app in Xcode or Android Studio
+### Debug the app in Xcode or Android Studio
 
 Start the metro development server
 
@@ -63,9 +77,9 @@ Start the metro development server
 npm start
 ```
 
-Then just open `ios/LightningApp.xcworkspace` from the finder on your mac. Or open the project in the `android` directory in Android Studio.
+Then just open `ios/LightningApp.xcworkspace` in Xcode, or open the project in the `android` directory in Android Studio.
 
-## Releasing
+## Generating release builds
 
 ### iOS
 
@@ -78,7 +92,7 @@ Then just open `ios/LightningApp.xcworkspace` from the finder on your mac. Or op
 ### Android
 
 1. Open Android Studio
-2. open the project in the `android` directory
+2. Open the project in the `android` directory
 3. Bump the `versionName` and `versionCode` under `app/build.gradle`
 4. From the menu `Build -> Clean Project`
 5. From the menu `Build -> Generate Signed Bundle / APK`


### PR DESCRIPTION
I wanted to add some more detailed guidance
for those who may be starting from scratch and
also link to existing docs which may help bridge
any knowledge gaps for new devs

Reorganized some sections to improve information
hierarchy and instructional flow

I also mentioned the mobile build tools that
haven't been merged yet, but in such a way that
the docs still make sense assuming the PR gets
merged in the v0.8.0 release

Open to feedback or further suggestions and I was
able to build on an iOS simulator successfully