### PR TITLE
Add note memo on txn detail for payments

### DIFF
--- a/src/action/transaction.js
+++ b/src/action/transaction.js
@@ -32,9 +32,8 @@ class TransactionAction {
    */
   async select({ item }) {
     this._store.selectedTransaction = item;
-
-    if (item.paymentRequest && item.paymentRequest.length > 0) {
-      await this.decodePayReqMemo({ payReq: item.paymentRequest });
+    if (item.paymentRequest) {
+      item.memo = await this.decodeMemo({ payReq: item.paymentRequest });
     }
     this._nav.goTransactionDetail();
     this.update();
@@ -122,19 +121,16 @@ class TransactionAction {
   /**
    * Attempt to decode a lightning payment request using the lnd grpc api.
    * @param  {string} options.payReq  The input to be validated
-   * @return {Promise<boolean>}       If the input is a valid invoice
+   * @return {Promise<string>}       If the input is a valid invoice
    */
-  async decodePayReqMemo({ payReq }) {
+  async decodeMemo({ payReq }) {
     try {
-      const { selectedTransaction } = this._store;
-      const request = await this._grpc.sendCommand('decodePayReq', {
+      const { description } = await this._grpc.sendCommand('decodePayReq', {
         payReq,
       });
-      selectedTransaction.memo = request.description;
-      return true;
+      return description;
     } catch (err) {
       log.info(`Decoding payment request failed: ${err.message}`);
-      return false;
     }
   }
 


### PR DESCRIPTION
Closes lightninglabs/lightning-app#977

Tested in an iOS simulator, but the feature
should be cross-platform as no UI changes were
needed and business logic was already in place
I could do more cross-platform testing if
necessary. Should be able to test for this
by pulling up any payment made to an invoice
that had a memo field

I tried to match existing code patterns as
closely as possible but not 100% familiar
with MobX anti-patterns

One thing worth mentioning is I expected the
UI to update when selectedTransaction was
mutated but that didn't seem to be the case
so I worked in the async/await before pushing
to TransactionDetail

Also added a few tests again mirroring existing
practices