### PR TITLE
ios native: pass localizedDescription as error message

### DIFF
--- a/mobile/ios/lightning/LndReactModule.m
+++ b/mobile/ios/lightning/LndReactModule.m
@@ -38,7 +38,7 @@ static NSString* const logEventName = @"logs";
 }
 
 - (void)onError:(NSError *)p0 {
-    self.reject(@"error", @"received error", p0);
+    self.reject(@"error", [p0 localizedDescription], p0);
 }
 
 - (void)onResponse:(NSData *)p0 {

--- a/src/action/payment.js
+++ b/src/action/payment.js
@@ -247,7 +247,7 @@ class PaymentAction {
       this._nav.goPayBitcoinConfirm();
     } catch (err) {
       this._notification.display({
-        msg: `Fee estimation failed: ${err.details}`,
+        msg: `Fee estimation failed: ${err}`,
         err,
       });
     }


### PR DESCRIPTION
It will also be part of the passed NSError, but this makes the error
message explicit.