### PR TITLE
Update tags for lnd to match released versions of lnd

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We will use `lnd` to make GRPC calls from the ReactJS environment
 ```
 git clone https://github.com/lightningnetwork/lnd $GOPATH/src/github.com/lightningnetwork/lnd
 cd $GOPATH/src/github.com/lightningnetwork/lnd
-make && make install tags="experimental autopilotrpc"
+make && make install tags="experimental autopilotrpc signrpc walletrpc chainrpc invoicesrpc routerrpc"
 ```
 If you have any issues with this step, make sure to review the [Preliniaries to installing LND](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md#preliminaries)
 

--- a/assets/script/build_app.sh
+++ b/assets/script/build_app.sh
@@ -12,7 +12,7 @@ if [ "$(uname)" == "Darwin" ]; then
 else
   # build binaries for windows
   cd $GOPATH/src/github.com/lightningnetwork/lnd
-  GOOS="windows" GOARCH="386" GO111MODULE="on" go build -tags="experimental autopilotrpc" -v github.com/lightningnetwork/lnd/cmd/lnd
+  GOOS="windows" GOARCH="386" GO111MODULE="on" go build -tags="experimental autopilotrpc signrpc walletrpc chainrpc invoicesrpc routerrpc" -v github.com/lightningnetwork/lnd/cmd/lnd
   cp lnd.exe $TRAVIS_BUILD_DIR/assets/bin/win32/
 
   # build the packages using electron-builder on docker

--- a/assets/script/install_lnd.sh
+++ b/assets/script/install_lnd.sh
@@ -20,7 +20,7 @@ cd $GOPATH/src/github.com/lightningnetwork/lnd
 git checkout $LND_TAG
 # enable mainnet neutrino in lnd
 git fetch https://github.com/halseth/lnd.git mainnet-neutrino:mainnet-neutrino && git cherry-pick mainnet-neutrino
-make && make install tags="experimental autopilotrpc"
+make && make install tags="experimental autopilotrpc signrpc walletrpc chainrpc invoicesrpc routerrpc"
 
 # install btcd
 git clone https://github.com/btcsuite/btcd $GOPATH/src/github.com/btcsuite/btcd


### PR DESCRIPTION
**Background:**
I work on [an app](https://sparkswap.com) that allows users to connect to our application with their own lightning nodes (including the node installed on Lightning App).

Specifically, our app relies on the `invoicesrpc` subserver in lnd that allows clients to utilize the `hodl invoice` functionality.

Releases for LND have all subserver RPCs, however the Lightning App only includes a small portion of those subservers.

This PR adds all subservers to build flags for the Lightning App.