### PR TITLE
bump version to 0.5.8-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
 
 env:
   global:
-    - LND_TAG=cd3c2b508ec45373602e3cdb9cd19ab7b224f94d
-    - BTCD_TAG=130ea5bddde33df32b06a1cdb42a6316eb73cff5
-    - GO_TAG=1.13
+    - LND_TAG=73ceb9a06eb19e727a9e6cf140bda8924df977eb
+    - BTCD_TAG=a41498d578a99c1619037746abd916176ea61052
+    - GO_TAG=1.13.3
     - GOROOT=$HOME/go
     - GOPATH=$HOME/gocode
     - PATH=$GOPATH/bin:$GOROOT/bin:$PATH

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-app",
-  "version": "0.5.7-alpha",
+  "version": "0.5.8-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-app",
-  "version": "0.5.7-alpha",
+  "version": "0.5.8-alpha",
   "description": "Lightning Wallet Application",
   "author": "Lightning Labs, Inc",
   "homepage": "./",


### PR DESCRIPTION
In this PR, we bump the version of the application. No major UI or behavioral changes have been made. Instead, we update to the latest version of `lnd` (`v0.8.0-beta`) as it contains several fixes for neutrino as well as general bug fixes. 