### PR TITLE
Update keychain-mobile.js

### DIFF
--- a/src/action/keychain-mobile.js
+++ b/src/action/keychain-mobile.js
@@ -18,7 +18,7 @@ class KeychainAction {
    */
   async setItem(key, value) {
     const options = {
-      accessible: this._RNKeychain.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      accessible: this._RNKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
     };
     const vKey = `${VERSION}_${key}`;
     await this._RNKeychain.setInternetCredentials(vKey, USER, value, options);


### PR DESCRIPTION
I believe this._RNKeychain.WHEN_UNLOCKED_THIS_DEVICE_ONLY is returning null instead of the right enum

it probably falls back to the default state, which is Keychain.ACCESSIBLE.WHEN_UNLOCKED

more can be read here: https://github.com/oblador/react-native-keychain