### PR TITLE
Update mobile/README.md on where to get falafel.

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -16,7 +16,7 @@ Ensure you have all the following dependencies installed for a complete developm
 * protoc (`brew install protobuf`)
 * `go get -u -v golang.org/x/tools/go/packages`
 * [gomobile](https://github.com/golang/go/wiki/Mobile) (`go get -u golang.org/x/mobile/cmd/gomobile`)
-* falafel (`go get -u github.com/halseth/falafel`)
+* falafel (`go get -u github.com/lightninglabs/falafel`)
 
 _Required for iOS_
 * Xcode


### PR DESCRIPTION
github.com/halseth/falafel is as of this writing on version 0.5 while the lightninglabs repo is on 0.6 and the build requires version 0.6. Looks like halseth is doing the commits in the lightninglabs repo as well so not really sure what is going on.