### PR TITLE
Add debug network security config to allow http traffic.

### DIFF
--- a/mobile/android/app/src/debug/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <!-- END OPTIONAL PERMISSIONS -->
 
     <application
+      android:networkSecurityConfig="@xml/network_security_config"
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Android api level 28+ seems to not allow http traffic by default. This breaks
react-native debugging that relies on fetching artifacts over http for quick
iteration. See react native github isse
https://github.com/facebook/react-native/issues/22375 for more details.